### PR TITLE
add merge capability to horizons() setter for SPC objects.

### DIFF
--- a/R/setters.R
+++ b/R/setters.R
@@ -530,11 +530,15 @@ setReplaceMethod("horizons", "SoilProfileCollection",
     # if hzidname for the SPC is present in the new data,
     
     # only merge if all horizon IDs in the SPC are also present in the new data
+    #   and there are new columns in value that are not in horizons already
     if((length(setdiff(unique(as.character(value[[hzidname(object)]])), hzID(object))) == 0) &
        any(!unique(names(value)) %in% unique(names(object@horizons)))) {
-      # and there are new columns in value that are not in horizons already
       to_merge <- c(names(value)[!names(value) %in% names(object@horizons)], idname(object), hzidname(object))
       object@horizons <- merge(object@horizons, value[,to_merge], all.x = TRUE, by = c(idname(object), hzidname(object)))
+      
+      # now, do updates to "old" columns so we do not duplicate
+      to_update <- names(value)[!names(value) %in% to_merge]
+      object@horizons[,to_update] <- value[match(object@horizons[,hzidname(object)], value[,hzidname(object)]), to_update]
       return(object)
     }
   }

--- a/tests/testthat/test-SPC-objects.R
+++ b/tests/testthat/test-SPC-objects.R
@@ -389,6 +389,8 @@ test_that("horizon slot set/merge", {
   hnew$prop200 <- hnew$prop / 200
   hnew$prop300 <- hnew$prop / 300
   
+  hnew$prop[1] <- 50
+  
   # utilize horizons() merge() functionality to add all new variables in hnew to horizons
   horizons(x) <- hnew
   
@@ -397,6 +399,9 @@ test_that("horizon slot set/merge", {
   
   # verify old columns have same names (i.e. no issues with duplication of column names in merge)
   expect_true(all(c(idname(x), hzidname(x), 'prop') %in% names(horizons(x))))
+  
+  # verify old columns have been updated
+  expect_equivalent(horizons(x)[1,c('prop')], c(50))
 })
 
 

--- a/tests/testthat/test-SPC-objects.R
+++ b/tests/testthat/test-SPC-objects.R
@@ -378,9 +378,26 @@ test_that("SPC horizon ID init conflicts", {
   
 })
 
-
-
-
+test_that("horizon slot set/merge", {
+  x <- sp1
+  
+  # take unique site ID, horizon ID, and corresponding property (clay)
+  hnew <- horizons(x)[, c(idname(x), hzidname(x), 'prop')]
+  
+  # do some calculation, create a few new variables
+  hnew$prop100 <- hnew$prop / 100
+  hnew$prop200 <- hnew$prop / 200
+  hnew$prop300 <- hnew$prop / 300
+  
+  # utilize horizons() merge() functionality to add all new variables in hnew to horizons
+  horizons(x) <- hnew
+  
+  # verify new columns have been added
+  expect_equivalent(horizons(x)[1,c('prop100','prop200','prop300')], c(0.13, 0.13 / 2, 0.13 / 3))
+  
+  # verify old columns have same names (i.e. no issues with duplication of column names in merge)
+  expect_true(all(c(idname(x), hzidname(x), 'prop') %in% names(horizons(x))))
+})
 
 
 


### PR DESCRIPTION
Here are some proposed changes to the `horizons()` setter that will auto-merge in new values, provided the input dataframe has the same profile_id/idname and hzID/hzidname.

Addresses #82 

So far, this passes tests and doesn't appear to nuke any preexisting functionality. I may have missed something, though, so I've created this branch for testing.

Install branch for testing:
```
devtools::install_github('ncss-tech/aqp@hzset', dependencies=FALSE, build=FALSE, upgrade=FALSE)
```

Example usage/tests:
```
library(aqp)
library(testthat)

# demo data
data(sp1, package = 'aqp')
depths(sp1) <- id ~ top + bottom
site(sp1) <- ~ group
x <- sp1

  # take unique site ID, horizon ID, and corresponding property (clay)
  hnew <- horizons(x)[, c(idname(x), hzidname(x), 'prop')]
  
  # do some calculation, create a few "new" variables
  hnew$prop100 <- hnew$prop / 100
  hnew$prop200 <- hnew$prop / 200
  hnew$prop300 <- hnew$prop / 300

  # update an "old" variable
  hnew$prop[1] <- 50

  # utilize horizons() merge() functionality to add all new variables in hnew to horizons
  #   AND update any changes to pre-existing variables (i.e. 'prop')
  horizons(x) <- hnew

  # essentially, the above line is shorthand for:
  # horizons(x) <- merge(horizons(x), hnew, by=c(idname(x), hzidname(x)), all.x = TRUE)
  #   except the merge only involves unique ID + "new" column names (i.e. in hnew)
  #   this is followed by an "update" of the "old" column name values
  
  # verify new columns have been added
  expect_equivalent(horizons(x)[1, c('prop100','prop200','prop300')], c(0.13, 0.13 / 2, 0.13 / 3))
  
  # verify old columns have same names (i.e. no duplication of column names by merge)
  expect_true(all(c(idname(x), hzidname(x), 'prop') %in% names(horizons(x))))'

  # verify old columns have been updated
  expect_equivalent(horizons(x)[1, 'prop'], 50)
```