### PR TITLE
upgrades to profileApply

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aqp
-Version: 1.18.4
-Date: 2020-01-06
+Version: 1.18.5
+Date: 2020-01-19
 Title: Algorithms for Quantitative Pedology
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut", "cre"), email = "dylan.beaudette@usda.gov"), person(given="Pierre", family="Roudier", email="roudierp@landcareresearch.co.nz", role = c("aut", "ctb")), person(given="Andrew", family="Brown", email="andrew.g.brown@usda.gov", role = c("aut", "ctb")))
 Author: Dylan Beaudette [aut, cre], Pierre Roudier [aut, ctb], Andrew Brown [aut, ctb]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
+# aqp 1.18.5 (2020-01-19)
+  * `profileApply()` enhancement for large `SoilProfileCollection` objects (https://github.com/ncss-tech/aqp/issues/112)
+  * add `profileApply()` `frameify` argument for `data.frame` output (https://github.com/ncss-tech/aqp/issues/111)
+  
 # aqp 1.18.4 (2020-01-06)
   * bug fix (rare) when setting / replacing horizon attributes (https://github.com/ncss-tech/aqp/issues/105)
   * bug fix in `colorQuantiles` until `farver` 2.0.2 is available on CRAN
   * `SoilProfileCollection` object gains new slot: `@restrictions`, fix old objects with `rebuildSPC()`
 
 # aqp 1.18.3 (2019-12-19)
-  * evalMissingData() gets new argument for relative vs. absolute evalulation of missing data
-  * horizonColorIndices() and associated functions c/o Andrew Brown
+  * `evalMissingData()` gets new argument for relative vs. absolute evalulation of missing data
+  * `horizonColorIndices()`, `harden.rubification()`, `harden.melanization()`, `thompson.bell.darkness()` and associated functions in soilColorIndices.R
   * fix for https://github.com/ncss-tech/aqp/issues/44
   * fix for https://github.com/ncss-tech/aqp/issues/66
   * new example data: `rowley2019`

--- a/R/SoilProfileCollection-iterators.R
+++ b/R/SoilProfileCollection-iterators.R
@@ -1,35 +1,127 @@
+
+if (!isGeneric("profileApply"))
+ 	setGeneric("profileApply", function(object, FUN, 
+ 	                                    simplify = TRUE,
+ 	                                    frameify = FALSE,
+ 	                                    chunk.size = 100,
+ 	                                    column.names = NULL,
+ 	                                    ...) standardGeneric("profileApply"))
+
+# made internal by AGB 2020/01/19
+#
 # analog to apply():
 # operates by profile, returns vector of length(object) or nrow(object)
-if (!isGeneric("profileApply"))
- 	setGeneric("profileApply", function(object, FUN, simplify=TRUE, ...) standardGeneric("profileApply"))
+.profileApply <- function(object, FUN, simplify=TRUE, ...) {
 
-setMethod(f='profileApply', signature='SoilProfileCollection',
-	function(object, FUN, simplify=TRUE, ...) {
-						
 		# get profile IDs
 		pIDs <- profile_id(object)
-					
+
 		# init empty list
 		l <- list()
-						
+
 		# iterate over SPC, spliting into a list of SPC_i ... SPC_n
 		for(i in seq_along(pIDs)) {
 			pID <- pIDs[i]
 			l[[pID]] <- do.call(FUN, list(object[i, ], ...))
 		}
-		
+
 		# optionally simplify
-		if(simplify) {
-			res <- unlist(l)
-			return(res)
-		}
-		else
-			return(l)
-	}
-)
+		if(simplify) 
+			return(unlist(l))
+		
+		return(l)
+}
 
-
-
-
-
-
+setMethod(f='profileApply', signature='SoilProfileCollection', function(object, FUN, 
+                        simplify = TRUE, 
+                        frameify = FALSE,
+                        chunk.size = floor(sqrt(length(object))), 
+                        column.names = NULL, 
+                        ...) {
+  if(simplify & frameify) {
+    # simplify and frameify are both TRUE -- ignoring simplify argument
+    simplify <- FALSE
+  }
+            
+  # total number of profiles we have to iterate over  
+  n <- length(object)
+  o.name <- idname(object)
+  o.hname <- hzidname(object)
+  
+  # split the SPC of size n into chunk.size chunks
+  chunk <- sort(1:n %% max(1, round(n / chunk.size))) + 1
+  
+  # we first iterate over list of chunks of size chunk.size, keeping lists smallish
+  # by dividing by a tunable factor -- set as 100 by default
+  # then we iterate through each chunk, calling FUN on each element (profile)
+  # then, concatenate the result into a list (or vector if simplify == TRUE)
+  res <- do.call('c', lapply(split(1:n, chunk), function(idx) {
+    .profileApply(object[idx,], FUN, simplify, ...)
+  }))
+  
+  # return profile IDs if it makes sense for result
+  if(length(res) == length(object))
+    names(res) <- profile_id(object)
+  
+  # return horizon IDs if it makes sense for result
+  if(!simplify & inherits(res, 'data.frame'))
+    if(nrow(res) == nrow(object)) 
+      names(res) <- hzID(object)   
+  
+  # combine a list (one element per profile) into data.frame result
+  if(!simplify & frameify) {
+    
+    # make sure the first result is a data.frame (i.e. FUN returns a data.frame)
+    if(is.data.frame(res[[1]])) {
+      
+      # make a big data.frame
+      res <- as.data.frame(do.call('rbind', res))
+      
+      # get ids
+      pid <- profile_id(object)
+      pid.by.hz <- horizons(object)[[o.name]]
+      hz.id <- hzID(object)
+      
+      # determine if merge of res into @horizon or @site is feasible/reasonable
+      # if so, we want to keep track of unique site and horizon IDs
+      
+      # if hzidname is in big df and all hzID in result are from parent object...
+      if(o.hname %in% colnames(res) & all(res[[o.hname]] %in% hz.id)) {
+        
+        # make a master site/horizon id table (all in SPC)
+        id.df <- data.frame(pid.by.hz, hz.id)
+        colnames(id.df) <- c(o.name, o.hname)
+        
+        # warn if some hz IDs are missing in result
+        if(!all(hz.id %in% res[[o.hname]])) {
+          warning("frameify found horizon ID (", o.hname, ") in result but some IDs are missing!", call.=FALSE)
+        }
+        
+        # do a left join, filling in any missing idname, hzidname from res with NA
+        res <- merge(id.df, res, all.x = TRUE)
+        
+      } else if(o.name %in% colnames(res) & all(res[[o.name]] %in% pid)) {
+        
+        # same as above, only for site level summaries (far more common)
+        id.df <- data.frame(pid.by.hz)
+        colnames(id.df) <- c(o.name)
+        
+        if(!all(pid %in% res[[o.name]])) {
+          # this shouldn't really happen -- usually a problem with FUN
+          warning("frameify found site ID (", o.name, ") in result but some IDs are missing!", call.=FALSE)
+        }
+        
+        # do a left join, filling in any missing idname from res with NA
+        res <- merge(id.df, res, all.x = TRUE)
+      }
+      
+      if(!is.null(column.names))
+        colnames(res) <- column.names
+      
+    } else {
+      warning("first result is not class `data.frame` and frameify is TRUE. defaulting to list output.", call. = FALSE)
+    }
+  }
+  
+  return(res)
+})

--- a/R/SoilProfileCollection-iterators.R
+++ b/R/SoilProfileCollection-iterators.R
@@ -79,7 +79,6 @@ setMethod(f='profileApply', signature='SoilProfileCollection', function(object, 
       
       # get ids
       pid <- profile_id(object)
-      pid.by.hz <- horizons(object)[[o.name]]
       hz.id <- hzID(object)
       
       # determine if merge of res into @horizon or @site is feasible/reasonable
@@ -89,6 +88,7 @@ setMethod(f='profileApply', signature='SoilProfileCollection', function(object, 
       if(o.hname %in% colnames(res) & all(res[[o.hname]] %in% hz.id)) {
         
         # make a master site/horizon id table (all in SPC)
+        pid.by.hz <- horizons(object)[[o.name]]
         id.df <- data.frame(pid.by.hz, hz.id)
         colnames(id.df) <- c(o.name, o.hname)
         
@@ -103,7 +103,7 @@ setMethod(f='profileApply', signature='SoilProfileCollection', function(object, 
       } else if(o.name %in% colnames(res) & all(res[[o.name]] %in% pid)) {
         
         # same as above, only for site level summaries (far more common)
-        id.df <- data.frame(pid.by.hz)
+        id.df <- data.frame(pid)
         colnames(id.df) <- c(o.name)
         
         if(!all(pid %in% res[[o.name]])) {
@@ -122,6 +122,9 @@ setMethod(f='profileApply', signature='SoilProfileCollection', function(object, 
       warning("first result is not class `data.frame` and frameify is TRUE. defaulting to list output.", call. = FALSE)
     }
   }
+  
+  if(simplify)
+   return(unlist(res))
   
   return(res)
 })

--- a/man/horizonColorIndices.Rd
+++ b/man/horizonColorIndices.Rd
@@ -4,7 +4,8 @@
 \alias{horizonColorIndices}
 \title{Horizon Color Indices}
 \usage{
-horizonColorIndices(p, hue = "m_hue", value = "m_value", chroma = "m_chroma")
+horizonColorIndices(p, hue = "m_hue", value = "m_value",
+  chroma = "m_chroma")
 }
 \arguments{
 \item{p}{A SoilProfileCollection}

--- a/man/profileApply-methods.Rd
+++ b/man/profileApply-methods.Rd
@@ -8,14 +8,18 @@
 
 \usage{
 # method for SoilProfileCollection objects
-profileApply(object, FUN, simplify=TRUE, ...)
+profileApply(object, FUN, simplify = TRUE, frameify = FALSE,
+                    chunk.size = 100, column.names = NULL, ...)
 }
 
 \arguments{
   \item{object}{a SoilProfileCollection}
   \item{FUN}{a function to be applied to each profile within the collection}
-  \item{simplify}{logical, should the result be simplified to a vector? see examples}
-	\item{\dots}{further arguments passsed to FUN}
+  \item{simplify}{logical, should the result be simplified to a vector? default: TRUE; see examples} 
+  \item{frameify}{logical, should the result be collapsed into a data.frame? default: FALSE; overrides simplify argument; see examples}
+  \item{chunk.size}{numeric, size of "chunks" for faster processing of large SoilProfileCollection objects; default: 100}
+  \item{column.names}{character, optional character vector to replace frameify-derived column names; should match length of \code{colnames()} from FUN result; default: NULL}
+	\item{\dots}{additional arguments passsed to FUN}
 }
 
 \section{Methods}{
@@ -23,7 +27,7 @@ profileApply(object, FUN, simplify=TRUE, ...)
 \item{\code{signature(object = "SoilProfileCollection")}}{}
 }}
 
-\value{When simplify is TRUE, a vector of length \code{nrow(object)} (horizon data) or of length \code{length(object)} (site data). When simplify is FALSE, a list is returned.}
+\value{When simplify is TRUE, a vector of length \code{nrow(object)} (horizon data) or of length \code{length(object)} (site data). When simplify is FALSE, a list is returned. When frameify is TRUE, a data.frame is returned. An attempt is made to identify \code{idname} and/or \code{hzidname} in the data.frame result, safely ensuring that IDs are preserved to facilitate merging profileApply result downstream.}
 
 \seealso{ \code{\link{slab}}, \code{\link{estimateSoilDepth}}}
 
@@ -34,11 +38,10 @@ depths(sp1) <- id ~ top + bottom
 # estimate soil depth using horizon designations
 profileApply(sp1, estimateSoilDepth, name='name', top='top', bottom='bottom')
 
-# scale properties within each profile
+# scale a single property 'prop' in horizon table
 # scaled = (x - mean(x)) / sd(x)
 sp1$d <- profileApply(sp1, FUN=function(x) round(scale(x$prop), 2))
 plot(sp1, name='d')
-
 
 # compute depth-wise differencing by profile
 # note that our function expects that the column 'prop' exists
@@ -51,7 +54,6 @@ plot(sp1, name='d')
 sp1$d <- profileApply(sp1, FUN=function(x) cumsum(x$prop))
 plot(sp1, name='d')
 
-
 # compute profile-means, and save to @site
 # there must be some data in @site for this to work
 site(sp1) <- ~ group
@@ -60,6 +62,40 @@ sp1$mean_prop <- profileApply(sp1, FUN=function(x) mean(x$prop, na.rm=TRUE))
 # re-plot using ranks defined by computed summaries (in @site)
 plot(sp1, plot.order=rank(sp1$mean_prop))
 
+## iterate over profiles, calculate on each horizon, merge into original SPC
+
+# example data
+data(sp1)
+
+# promote to SoilProfileCollection
+depths(sp1) <- id ~ top + bottom
+site(sp1) <- ~ group
+
+# calculate horizon thickness and proportional thickness
+# returns a data.frame result with multiple attributes per horizon
+thicknessFunction <- function(p) {
+  hz <- horizons(p)
+  depthnames <- horizonDepths(p)
+  res <- data.frame(profile_id(p), hzID(p), 
+                    thk=(hz[[depthnames[[2]]]] - hz[[depthnames[1]]]))
+  res$hz_prop <- res$thk / sum(res$thk)
+  colnames(res) <- c(idname(p), hzidname(p), 'hz_thickness', 'hz_prop')
+  return(res)
+}
+
+# list output option with simplify=F, list names are profile_id(sp1)
+list.output <- profileApply(sp1, thicknessFunction, simplify = FALSE)
+head(list.output)
+
+# data.frame output option with frameify=TRUE
+df.output <- profileApply(sp1, thicknessFunction, frameify = TRUE)
+head(df.output)
+
+# since df.output contains idname(sp1) and hzidname(sp1), 
+# it can safely be merged by a left-join via horizons<- setter
+horizons(sp1) <- df.output
+
+plot(density(sp1$hz_thickness, na.rm=TRUE), main="Density plot of Horizon Thickness")
 
 ## iterate over profiles, subsetting horizon data
 

--- a/man/thompson.bell.darkness.Rd
+++ b/man/thompson.bell.darkness.Rd
@@ -4,13 +4,8 @@
 \alias{thompson.bell.darkness}
 \title{Thompson-Bell (1996) Index}
 \usage{
-thompson.bell.darkness(
-  p,
-  name = NULL,
-  pattern = "^A",
-  value = "m_value",
-  chroma = "m_chroma"
-)
+thompson.bell.darkness(p, name = NULL, pattern = "^A",
+  value = "m_value", chroma = "m_chroma")
 }
 \arguments{
 \item{p}{A single-profile SoilProfileCollection (e.g. via profileApply())}

--- a/tests/testthat/test-profileApply.R
+++ b/tests/testthat/test-profileApply.R
@@ -1,0 +1,25 @@
+context("profileApply - SoilProfileCollection iterator")
+
+data(sp1, package = 'aqp')
+depths(sp1) <- id ~ top + bottom
+site(sp1) <- ~ group
+
+attr <- 'prop' # clay contents % 
+
+test_that("profileApply - basic tests of output datatypes", {
+  r1 <- profileApply(sp1, estimateSoilDepth, name="name", top="top", bottom="bottom")
+  expect_equal(names(r1),c("P001", "P002", "P003", "P004", "P005", "P006", "P007", "P008", "P009"))
+  expect_equal(r1, c(P001 = 89L, P002 = 59L, P003 = 67L, P004 = 62L, P005 = 68L, P006 = 200L, P007 = 233L, P008 = 200L, P009 = 240L))
+  
+  r2 <- profileApply(sp1, estimateSoilDepth, name="name", top="top", bottom="bottom", simplify = FALSE)
+  expect_equal(r2, list(P001 = 89L, P002 = 59L, P003 = 67L, P004 = 62L, P005 = 68L, 
+                        P006 = 200L, P007 = 233L, P008 = 200L, P009 = 240L))
+  
+  r3 <- profileApply(sp1, function(p) {
+      d <- estimateSoilDepth(p, name="name", top="top", bottom="bottom")
+      res <- data.frame(profile_id(p), d)
+      colnames(res) <- c(idname(p), "soildepthest")
+      return(res)
+    }, frameify = TRUE)
+  expect_true(inherits(r3,'data.frame'))
+})


### PR DESCRIPTION
Addressing issues #111 #112 

Before upgrade:
  
```
> devtools::load_all()
Loading aqp
This is aqp 1.18.4
> foo <- do.call('rbind', lapply(as.list(1:2000), random_profile))
> depths(foo) <- id ~ top + bottom
> system.time(profileApply(foo, simpleFunction))
user  system elapsed 
18.893   0.160  19.967 
```

After "chunkApply" upgrade, nearly 4x faster processing of 2000 pedons.
  
```
> devtools::load_all()
Loading aqp
This is aqp 1.18.5
> foo <- do.call('rbind', lapply(as.list(1:2000), random_profile))
> depths(foo) <- id ~ top + bottom
> system.time(profileApply(foo, simpleFunction))
user  system elapsed 
5.528   0.057   5.837 
```

With `frameify = TRUE`:
  
```
> system.time(foo <- profileApply(foo, simpleFunction, frameify = TRUE))
user  system elapsed 
5.690   0.088   6.073 
```

"Simple" function that calculates horizon thickness and proportional thickness. 

Internal management of `idname` and `hzidname` by `frameify` facilitates taking stock of potentially incomplete results before _safely_ merging (e.g. using `site<-` or `horizons<-`) -- presuming `hzidname` is returned in the result from calling `FUN`.

``` 
simpleFunction <- function(p) {
  hz <- horizons(p)
  res <- data.frame(profile_id(p), hzID(p), thk=(hz$bottom - hz$top))
  res$hz_prop <- res$thk / sum(res$thk)
  # optional: return just second and third horizon to test merge result
  #res <- res[2:3,]
  colnames(res) <- c(idname(p), hzidname(p), 'hz_thickness', 'hz_prop')
  return(res)
}
```