### PR TITLE
data.table optimization of SPC j-index and adding k-keywords

### DIFF
--- a/R/SoilProfileCollection-operators.R
+++ b/R/SoilProfileCollection-operators.R
@@ -152,10 +152,10 @@ setMethod("[", signature(x = "SoilProfileCollection",
                   if (length(j.idx) == 0) {
                     i.idx <- numeric(0)
                   } else {
-                    # determine which profile IDs KEEP
-                    pids <- h[, .I[any(1:.N %in% j)][1], by = bylist]
-                    i.idx <- pids[, .I[!is.na(V1)]]
+                    # determine which profiles to  KEEP
+                    i.idx <- which(profile_id(x) %in% unique(h[j.idx,][[idn]]))
                   }
+
                 # }
               # } else {
               #   # retain a base R way of doing things (plenty fast with SPCs up to ~100k or so)

--- a/R/SoilProfileCollection-operators.R
+++ b/R/SoilProfileCollection-operators.R
@@ -14,7 +14,7 @@
 #'
 #' @aliases  [,SoilProfileCollection-method
 #'
-#' @description You can access the contents of a SoilProfileCollection by profile and horizon "index", \code{i} and \code{j}, respectively: \code{spc[i, j]}. Subset operations are propagated to other slots when they result in removal of sites from a collection.
+#' @description You can access the contents of a SoilProfileCollection by profile and horizon "index", \code{i} and \code{j}, respectively: \code{spc[i, j, ...]}. Subset operations are propagated to other slots (such as diagnostics or spatial) when they result in removal of sites from a collection.
 #'
 #'  - \code{i} refers to the profile position within the collection. By default the order is based on the C SORT order of the variable that you specified as your unique profile ID at time of object construction. Note that if your ID variable was numeric, then it has been sorted as a character.
 #'
@@ -22,12 +22,15 @@
 #'
 #'  - `...` is an area to specify an expression that is evaluated in the subset. Currently supported
 #'
-#'    - `.LAST`: return the last horizon from each profile. This uses `i` but ignores the regular `j` index.
+#'    - `.LAST` (last horizon in each profile): return the last horizon from each profile. This uses `i` but ignores the regular `j` index.
+#'    - `.FIRST` (first horizon in each profile): return the last horizon from each profile. This uses `i` but ignores the regular `j` index.
+#'    - `.HZID` (horizon index not `SoilProfileCollection` result): return the horizon indices corresponding to `i`+`j`+`...` ("k") constraints
 #'
 #' @param x a SoilProfileCollection
 #' @param i a numeric or logical value denoting profile indices to select in a subset
 #' @param j a numeric or logical value denoting horizon indices to select in a subset
-#' @param ... non-standard expressions to evaluate in a subset; currently supported: `.LAST` (last horizon in each profile)
+#' @param ... non-standard expressions to evaluate in a subset
+#' 
 #' @param drop not used
 #' @rdname singlebracket
 #  SPC extract: "[" '[' single bracket SPC object extract method

--- a/R/SoilProfileCollection-operators.R
+++ b/R/SoilProfileCollection-operators.R
@@ -124,7 +124,9 @@ setMethod("[", signature(x = "SoilProfileCollection",
             if (!missing(j)) {
 
               # faster replacement of j subsetting of horizon data
-              if (aqp_df_class(x) == "data.table") {
+              # if (aqp_df_class(x) == "data.table") {
+
+                h <- as.data.table(h)
 
                 # local vars to make R CMD check happy
                 .N <- NULL
@@ -132,7 +134,7 @@ setMethod("[", signature(x = "SoilProfileCollection",
                 V1 <- NULL
 
                 # data.table can do this much more efficiently
-                if (requireNamespace("data.table", quietly = TRUE)) {
+                # if (requireNamespace("data.table", quietly = TRUE)) {
                   idn <- idname(x)
 
                   # by list @horizons idname (essentially iterating over profiles)
@@ -154,25 +156,24 @@ setMethod("[", signature(x = "SoilProfileCollection",
                     pids <- h[, .I[any(1:.N %in% j)][1], by = bylist]
                     i.idx <- pids[, .I[!is.na(V1)]]
                   }
-                }
-
-              } else {
-                # retain a base R way of doing things (plenty fast with SPCs up to ~100k or so)
-                j.res <- as.list(aggregate(
-                  h[[hzidname(x)]],
-                  by = list(h[[idname(x)]]),
-                  FUN = function(hh) {
-                    list(1:length(hh) %in% j)
-                  },
-                  drop = FALSE
-                )$x)
-
-                ##  https://github.com/ncss-tech/aqp/issues/89
-                # fix #89, where i with no matching j e.g. @site data returned
-                i.idx <- which(as.logical(lapply(j.res, function(jr) { any(jr) })))
-
-                j.idx <-  which(do.call('c', j.res))
-              }
+                # }
+              # } else {
+              #   # retain a base R way of doing things (plenty fast with SPCs up to ~100k or so)
+              #   j.res <- as.list(aggregate(
+              #     h[[hzidname(x)]],
+              #     by = list(h[[idname(x)]]),
+              #     FUN = function(hh) {
+              #       list(1:length(hh) %in% j)
+              #     },
+              #     drop = FALSE
+              #   )$x)
+              #
+              #   ##  https://github.com/ncss-tech/aqp/issues/89
+              #   # fix #89, where i with no matching j e.g. @site data returned
+              #   i.idx <- which(as.logical(lapply(j.res, function(jr) { any(jr) })))
+              #
+              #   j.idx <-  which(do.call('c', j.res))
+              # }
 
               # find any index out of bounds and ignore them
               # j.idx.bad <- which(abs(j.idx) > nrow(h))

--- a/man/singlebracket.Rd
+++ b/man/singlebracket.Rd
@@ -4,19 +4,27 @@
 \alias{[,SoilProfileCollection-method}
 \title{Matrix/data.frame-like access to profiles and horizons in a SoilProfileCollection}
 \usage{
-\S4method{[}{SoilProfileCollection}(x, i, j)
+\S4method{[}{SoilProfileCollection}(x, i, j, ..., drop = TRUE)
 }
 \arguments{
 \item{x}{a SoilProfileCollection}
 
 \item{i}{a numeric or logical value denoting profile indices to select in a subset}
 
-\item{j}{a numeric or logical value denoting profile indices to select in a subset}
+\item{j}{a numeric or logical value denoting horizon indices to select in a subset}
+
+\item{...}{non-standard expressions to evaluate in a subset; currently supported: \code{.LAST} (last horizon in each profile)}
+
+\item{drop}{not used}
 }
 \description{
 You can access the contents of a SoilProfileCollection by profile and horizon "index", \code{i} and \code{j}, respectively: \code{spc[i, j]}. Subset operations are propagated to other slots when they result in removal of sites from a collection.
-
-\code{i} refers to the profile position within the collection. By default the order is based on the C SORT order of the variable that you specified as your unique profile ID at time of object construction. Note that if your ID variable was numeric, then it has been sorted as a character.
-
-\code{j} refers to the horizon or "slice" index. This index is most useful when either a) working with \code{slice}'d SoilProfileCollection or b) working with single-profile collections. \code{j} returns the layer in the specified index positions for all profiles in a collection. So, for instance, if \code{spc} contained 100 profiles, \code{spc[,2]} would return 100 profiles, but just the second horizon from each of the profiles ... assuming each profile had at least two horizons! The single horizon profiles would be dropped from the collection.
+\itemize{
+\item \code{i} refers to the profile position within the collection. By default the order is based on the C SORT order of the variable that you specified as your unique profile ID at time of object construction. Note that if your ID variable was numeric, then it has been sorted as a character.
+\item \code{j} refers to the horizon or "slice" index. This index is most useful when either a) working with \code{slice}'d SoilProfileCollection or b) working with single-profile collections. \code{j} returns the layer in the specified index positions for all profiles in a collection.
+\item \code{...} is an area to specify an expression that is evaluated in the subset. Currently supported
+\itemize{
+\item \code{.LAST}: return the last horizon from each profile. This uses \code{i} but ignores the regular \code{j} index.
+}
+}
 }

--- a/man/singlebracket.Rd
+++ b/man/singlebracket.Rd
@@ -13,18 +13,20 @@
 
 \item{j}{a numeric or logical value denoting horizon indices to select in a subset}
 
-\item{...}{non-standard expressions to evaluate in a subset; currently supported: \code{.LAST} (last horizon in each profile)}
+\item{...}{non-standard expressions to evaluate in a subset}
 
 \item{drop}{not used}
 }
 \description{
-You can access the contents of a SoilProfileCollection by profile and horizon "index", \code{i} and \code{j}, respectively: \code{spc[i, j]}. Subset operations are propagated to other slots when they result in removal of sites from a collection.
+You can access the contents of a SoilProfileCollection by profile and horizon "index", \code{i} and \code{j}, respectively: \code{spc[i, j, ...]}. Subset operations are propagated to other slots (such as diagnostics or spatial) when they result in removal of sites from a collection.
 \itemize{
 \item \code{i} refers to the profile position within the collection. By default the order is based on the C SORT order of the variable that you specified as your unique profile ID at time of object construction. Note that if your ID variable was numeric, then it has been sorted as a character.
 \item \code{j} refers to the horizon or "slice" index. This index is most useful when either a) working with \code{slice}'d SoilProfileCollection or b) working with single-profile collections. \code{j} returns the layer in the specified index positions for all profiles in a collection.
 \item \code{...} is an area to specify an expression that is evaluated in the subset. Currently supported
 \itemize{
-\item \code{.LAST}: return the last horizon from each profile. This uses \code{i} but ignores the regular \code{j} index.
+\item \code{.LAST} (last horizon in each profile): return the last horizon from each profile. This uses \code{i} but ignores the regular \code{j} index.
+\item \code{.FIRST} (first horizon in each profile): return the last horizon from each profile. This uses \code{i} but ignores the regular \code{j} index.
+\item \code{.HZID} (horizon index not \code{SoilProfileCollection} result): return the horizon indices corresponding to \code{i}+\code{j}+\code{...} ("k") constraints
 }
 }
 }

--- a/misc/aqp2/jindex-benchmarks.R
+++ b/misc/aqp2/jindex-benchmarks.R
@@ -158,6 +158,7 @@ hundredthousand <- as.data.frame(data.table::rbindlist(lapply(1:100000, random_p
 depths(hundredthousand) <- id ~ top + bottom
 
 bench::mark(spc_j_base(hundredthousand, 1:10, 2:3),
+            spc_j_base_2(hundredthousand, 1:10, 2:3),
             spc_j_DT(hundredthousand, 1:10, 2:3),
             spc_j_DT_2(hundredthousand, 1:10, 2:3))
 

--- a/misc/aqp2/jindex-benchmarks.R
+++ b/misc/aqp2/jindex-benchmarks.R
@@ -1,0 +1,146 @@
+spc_j_DT <- function(x, i, j) {
+
+  #  this is already live in AQP for data.table SPCs -- is it worth enabling globally?
+
+  h <- data.table::as.data.table(horizons(x))
+
+  # local vars to make R CMD check happy
+  .N <- NULL
+  .I <- NULL
+  V1 <- NULL
+
+  # data.table can do this much more efficiently
+  # if (requireNamespace("data.table", quietly = TRUE)) {
+  idn <- idname(x)
+
+  # by list @horizons idname (essentially iterating over profiles)
+  bylist <- list(h[[idn]])
+  names(bylist) <- idn
+
+  # figured out the data.table way to do this
+  #  not using := or . anymore
+
+  # determine j indices to KEEP
+  j.idx <- h[, .I[1:.N %in% j], by = bylist]$V1
+
+  # determine which site indices to keep
+  # in case all horizons are removed, remove sites too
+  if (length(j.idx) == 0) {
+    i.idx <- numeric(0)
+  } else {
+    # determine which profile IDs KEEP
+    pids <- h[, .I[any(1:.N %in% j)][1], by = bylist]
+    i.idx <- pids[, .I[!is.na(V1)]]
+  }
+  return(list(i.idx, j.idx))
+}
+
+# benchmark faster replacement of j subsetting of horizon data
+
+spc_j_DT_2 <- function(x, i, j) {
+
+  #  this is already live in AQP for data.table SPCs
+  # question: is it worth enabling globally?
+
+  h <- data.table::as.data.table(horizons(x))
+
+  # local vars to make R CMD check happy
+  .N <- NULL
+  .I <- NULL
+  V1 <- NULL
+
+  idn <- idname(x)
+
+  # by list @horizons idname (essentially iterating over profiles)
+  bylist <- list(h[[idn]])
+  names(bylist) <- idn
+
+  # figured out the data.table way to do this
+  #  not using := or . anymore
+
+  # determine j indices to KEEP
+  j.idx <- h[, .I[1:.N %in% j], by = bylist]$V1
+
+  # determine which site indices to keep
+  # in case all horizons are removed, remove sites too
+  if (length(j.idx) == 0) {
+    i.idx <- numeric(0)
+  } else {
+    # determine which profile IDs KEEP
+    i.idx <- which(profile_id(x) %in% unique(h[j.idx,][[idn]]))
+  }
+  return(list(i.idx, j.idx))
+}
+
+spc_j_base <- function(x, i, j) {
+    h <- horizons(x)
+    # retain a base R way of doing things (plenty fast with SPCs up to ~100k or so)
+    j.res <- as.list(aggregate(
+        h[[hzidname(x)]],
+        by = list(h[[idname(x)]]),
+        FUN = function(hh) {
+          list(1:length(hh) %in% j)
+        },
+        drop = FALSE
+      )$x)
+
+    ##  https://github.com/ncss-tech/aqp/issues/89
+    # fix #89, where i with no matching j e.g. @site data returned
+    i.idx <- which(as.logical(lapply(j.res, function(jr) { any(jr) })))
+    j.idx <-  which(do.call('c', j.res))
+
+    return(list(i.idx, j.idx))
+}
+
+library(aqp)
+
+data(sp4)
+depths(sp4) <- id ~ top + bottom
+
+# base outperforms old DT with 10 profiles, but new solution slightly better
+microbenchmark::microbenchmark(spc_j_base(sp4, 1:10, 2),
+                               spc_j_DT(sp4, 1:10, 2),
+                               spc_j_DT_2(sp4, 1:10, 2))
+
+# whether the SPC is a "data.table SPC" ahead of time does not affect overhead much
+sp4_DT <- data.table::as.data.table(horizons(sp4))
+depths(sp4_DT) <- id ~ top + bottom
+
+bench::mark(spc_j_base(sp4_DT, 1:10, 2:3),
+            spc_j_DT(sp4_DT, 1:10, 2:3),
+            spc_j_DT_2(sp4_DT, 1:10, 2:3))
+
+# basically neck-and-neck at 1000 profiles; closing the gap of base over DT from ~50% to about ~5%
+# the new solution is 200% faster than both old ones
+thousand <- as.data.frame(data.table::rbindlist(lapply(1:1000, random_profile)))
+depths(thousand) <- id ~ top + bottom
+
+bench::mark(spc_j_base(thousand, 1:10, 2:3),
+            spc_j_DT(thousand, 1:10, 2:3),
+            spc_j_DT_2(thousand, 1:10, 2:3))
+
+# ten thousand profiles, we see a benefit from DT (old: ~20% faster than base; new 300% faster)
+tenthousand <- as.data.frame(data.table::rbindlist(lapply(1:10000, random_profile)))
+depths(tenthousand) <- id ~ top + bottom
+
+bench::mark(spc_j_base(tenthousand, 1:10, 2:3),
+            spc_j_DT(tenthousand, 1:10, 2:3),
+            spc_j_DT_2(tenthousand, 1:10, 2:3))
+
+# hundred thousand profiles, we see a similar benefit from DT -- 2 to 3 times faster
+hundredthousand <- as.data.frame(data.table::rbindlist(lapply(1:100000, random_profile)))
+depths(hundredthousand) <- id ~ top + bottom
+
+bench::mark(spc_j_base(hundredthousand, 1:10, 2:3),
+            spc_j_DT(hundredthousand, 1:10, 2:3),
+            spc_j_DT_2(hundredthousand, 1:10, 2:3))
+
+# # million profiles, we see a benefit from DT
+# million <- as.data.frame(data.table::rbindlist(lapply(1:1000000, random_profile)))
+# depths(million) <- id ~ top + bottom
+#
+# bench::mark(
+#   spc_j_base(million, 1:10, 2:3),
+#   spc_j_DT(million, 1:10, 2:3),
+#   spc_j_DT_2(hundredthousand, 1:10, 2:3)
+# )

--- a/misc/aqp2/jindex-benchmarks.R
+++ b/misc/aqp2/jindex-benchmarks.R
@@ -114,6 +114,25 @@ spc_j_base_2 <- function(x, i, j) {
   return(list(i.idx, j.idx))
 }
 
+spc_j_base_3 <- function(x, i, j) {
+  h <- horizons(x)
+  idn <- idname(x)
+
+  # slightly more competitive version of base
+  j.res <- aggregate(
+    seq_len(nrow(h)),
+    by = list(h[[idn]]),
+    FUN = function(hh) {
+      (1:length(hh) %in% j)
+    }
+  )$x
+
+  i.idx <- which(vapply(j.res, any, FUN.VALUE = logical(1)))
+  j.idx <-  which(unlist(j.res))
+
+  return(list(i.idx, j.idx))
+}
+
 library(aqp)
 
 data(sp4)
@@ -122,6 +141,7 @@ depths(sp4) <- id ~ top + bottom
 # base outperforms old DT with 10 profiles, but new solution slightly better
 microbenchmark::microbenchmark(spc_j_base(sp4, 1:10, 2:3),
                                spc_j_base_2(sp4, 1:10, 2:3),
+                               spc_j_base_3(sp4, 1:10, 2:3),
                                spc_j_DT(sp4, 1:10, 2:3),
                                spc_j_DT_2(sp4, 1:10, 2:3))
 
@@ -131,6 +151,7 @@ depths(sp4_DT) <- id ~ top + bottom
 
 bench::mark(spc_j_base(sp4_DT, 1:10, 2:3),
             spc_j_base_2(sp4_DT, 1:10, 2:3),
+            spc_j_base_3(sp4_DT, 1:10, 2:3),
             spc_j_DT(sp4_DT, 1:10, 2:3),
             spc_j_DT_2(sp4_DT, 1:10, 2:3))
 
@@ -141,6 +162,7 @@ depths(thousand) <- id ~ top + bottom
 
 bench::mark(spc_j_base(thousand, 1:10, 2:3),
             spc_j_base_2(thousand, 1:10, 2:3),
+            spc_j_base_3(thousand, 1:10, 2:3),
             spc_j_DT(thousand, 1:10, 2:3),
             spc_j_DT_2(thousand, 1:10, 2:3))
 
@@ -150,17 +172,19 @@ depths(tenthousand) <- id ~ top + bottom
 
 bench::mark(spc_j_base(tenthousand, 1:10, 2:3),
             spc_j_base_2(tenthousand, 1:10, 2:3),
+            spc_j_base_3(tenthousand, 1:10, 2:3),
             spc_j_DT(tenthousand, 1:10, 2:3),
             spc_j_DT_2(tenthousand, 1:10, 2:3))
 
 # hundred thousand profiles, we see a similar benefit from DT -- 2 to 3 times faster
-hundredthousand <- as.data.frame(data.table::rbindlist(lapply(1:100000, random_profile)))
-depths(hundredthousand) <- id ~ top + bottom
-
-bench::mark(spc_j_base(hundredthousand, 1:10, 2:3),
-            spc_j_base_2(hundredthousand, 1:10, 2:3),
-            spc_j_DT(hundredthousand, 1:10, 2:3),
-            spc_j_DT_2(hundredthousand, 1:10, 2:3))
+# hundredthousand <- as.data.frame(data.table::rbindlist(lapply(1:100000, random_profile)))
+# depths(hundredthousand) <- id ~ top + bottom
+#
+# bench::mark(spc_j_base(hundredthousand, 1:10, 2:3),
+#             spc_j_base_2(hundredthousand, 1:10, 2:3),
+#             spc_j_base_3(hundredthousand, 1:10, 2:3),
+#             spc_j_DT(hundredthousand, 1:10, 2:3),
+#             spc_j_DT_2(hundredthousand, 1:10, 2:3))
 
 # # million profiles, we see a benefit from DT
 # million <- as.data.frame(data.table::rbindlist(lapply(1:1000000, random_profile)))

--- a/misc/aqp2/test-k-keywords.R
+++ b/misc/aqp2/test-k-keywords.R
@@ -1,0 +1,47 @@
+# DEMO: base non-standard eval of keyword in ... "k-index": SPC[i, j, ...]
+# version 1: add support for .LAST
+# version 2: add support for .FIRST, .HZID and multiple special keywords
+
+library(aqp, warn = FALSE)
+
+data(sp4)
+depths(sp4) <- id ~ top + bottom
+
+# .LAST
+sp4[, , .LAST]
+sp4[, , .HZID]
+sp4[, , .LAST, .HZID]
+sp4[, , .FIRST, .HZID] # this just sets j <- 1
+sp4[, 1000, .FIRST, .HZID] # this sets j <- 1; ignores j input if given
+sp4[, 1000, .LAST, .HZID] # this ignores j input if given
+
+# horizon index of 2nd horizon in each profile
+sp4[5:10, 2, .HZID]
+
+# this is more realistic, perhaps:
+fivetoten <- sp4[5:10,] # or some more complicated subset()
+
+# third horizon ID, index to horizon data.frame
+horizons(fivetoten)[fivetoten[,3,,.HZID],]
+
+# use it to implement #199
+getLastHorizonID_v1 <- function(x) {
+  res <-  hzID(x[, , .LAST])
+  names(res) <- profile_id(x)
+  return(res)
+}
+
+# ~4x more efficient using j-index shortcut
+getLastHorizonID_v2 <- function(x) {
+  res <-  hzID(x)[x[, , .LAST, .HZID]]
+  names(res) <- profile_id(x)
+  return(res)
+}
+
+bench::mark(getLastHorizonID_v1(sp4),
+            getLastHorizonID_v2(sp4))
+
+# bigger <- data.table::rbindlist(lapply(1:100000, random_profile))
+# depths(bigger) <- id ~ top + bottom
+# bench::mark(x <- getLastHorizonID_v1(bigger),
+#             x <- getLastHorizonID_v2(bigger))

--- a/misc/aqp2/test-k-keywords.R
+++ b/misc/aqp2/test-k-keywords.R
@@ -12,6 +12,7 @@ sp4[, , .LAST]
 sp4[, , .HZID]
 sp4[, , .LAST, .HZID]
 sp4[, , .FIRST, .HZID] # this just sets j <- 1
+sp4[, 1, , .HZID]
 sp4[, 1000, .FIRST, .HZID] # this sets j <- 1; ignores j input if given
 sp4[, 1000, .LAST, .HZID] # this ignores j input if given
 
@@ -31,7 +32,7 @@ getLastHorizonID_v1 <- function(x) {
   return(res)
 }
 
-# ~4x more efficient using j-index shortcut
+# ~3x more efficient using j-index shortcut
 getLastHorizonID_v2 <- function(x) {
   res <-  hzID(x)[x[, , .LAST, .HZID]]
   names(res) <- profile_id(x)
@@ -41,7 +42,7 @@ getLastHorizonID_v2 <- function(x) {
 bench::mark(getLastHorizonID_v1(sp4),
             getLastHorizonID_v2(sp4))
 
-# bigger <- data.table::rbindlist(lapply(1:100000, random_profile))
+# bigger <- data.table::rbindlist(lapply(1:1000, random_profile))
 # depths(bigger) <- id ~ top + bottom
 # bench::mark(x <- getLastHorizonID_v1(bigger),
 #             x <- getLastHorizonID_v2(bigger))

--- a/tests/testthat/test-SPC-k-keywords.R
+++ b/tests/testthat/test-SPC-k-keywords.R
@@ -1,0 +1,35 @@
+# base non-standard eval of keyword in ... "k-index": SPC[i, j, ...]
+#  support for .LAST, .FIRST, .HZID special keywords
+context(".LAST, .FIRST, .HZID k-keywords for SoilProfileCollection objects")
+
+# define special symbols in global env 
+# (not needed for tests, but needed wherever they are used in package)
+.FIRST <- NULL
+.LAST <- NULL
+.HZID <- NULL
+
+data(sp4)
+depths(sp4) <- id ~ top + bottom
+
+# .LAST
+expect_equal(length(sp4[, , .LAST]), 10)
+
+expect_equal(sp4[, , .HZID], 1:30)
+
+expect_equal(sp4[, , .LAST, .HZID], 
+             c(4L, 6L, 9L, 13L, 16L, 18L, 20L, 22L, 27L, 30L))
+# .FIRST sets j <- 1
+expect_equal(sp4[, , .FIRST, .HZID], 
+             sp4[, 1, , .HZID])
+
+# .FIRST ignores j input if given
+expect_equal(sp4[, 1000, .FIRST, .HZID], 
+             sp4[, 1, , .HZID])
+
+# .LAST ignores j input if given
+expect_equal(sp4[, , .LAST, .HZID],
+             sp4[, 1000, .LAST, .HZID])
+
+# horizon index of 2nd horizon in each profile
+expect_equal(sp4[5:10, 2, .HZID],
+             c(15L, 18L, 20L, 22L, 24L, 29L))


### PR DESCRIPTION
This was inspired by discussion on #199, a continuation of the efforts in #157 and of prior optimizations of SPC operators, and customizations for data.table SPCs in #155. This PR is extending the benefits for all SPC data.frame subclasses.

EDIT:
 - [x] we need to strongly consider tradeoffs of set-up/teardown of data.table approaches, considering subset operations are disproportionately applied to smaller SPCs, optimizing specifically for large SPCs may be the wrong target. <strike>Triggering more performant code at a length(SPC) threshold e.g. 10000 may be an idea to consider.</strike>
 
EDIT2:
Agreeing with Dylan below. I reverted this to draft for now. 

Some more explanation. Before this PR, data.table SPC j-index should only be invoked if the `aqp_df_class` of the object is `"data.table"`. This PR removes one of the few code "forks" between data.table and base in favor of a data.table. 

We could more formally "archive" base R equivalent code using in tests where things should be expected to be the same. For now, I left mine commented, and several new realizations of the base code in this PR worth trying out.

In some way I see git/PR/issue history as documentation of some decisions and options, but that isn't ideal. The current state of things in _master_ reflects my best judgment [at the time] about when to invoke data.table -- usually based on some fairly thoughtful benchmarks, but imperfect and a product of their time to be sure. As this PR reveals.

I think I would be willing to accept a small performance hit for small SPCs in exchange for better scaling. Possibly being less if we adopted data.table as a paradigm, unclear to me at this point where/when exactly the performance hit happens. 

There may be plenty of cases where _using_ data.table rather than a base approach is not necessary (even if the object is a data.table). Please check out the _jindex-benchmarks.R_ file on this `dtspcj` branch if interested, but the small-SPC benchmark "concerning" me is this one

```
> microbenchmark::microbenchmark(spc_j_base(sp4, 1:10, 2:3),
+                                spc_j_base_2(sp4, 1:10, 2:3),
+                                spc_j_base_3(sp4, 1:10, 2:3),
+                                spc_j_DT(sp4, 1:10, 2:3),
+                                spc_j_DT_2(sp4, 1:10, 2:3))
Unit: microseconds
                         expr      min        lq      mean    median       uq      max neval
   spc_j_base(sp4, 1:10, 2:3)  990.893 1049.6240 1344.2467 1095.1280 1146.255 8960.763   100
 spc_j_base_2(sp4, 1:10, 2:3)  885.724  931.8925  973.7731  955.7965 1003.316 1247.136   100
 spc_j_base_3(sp4, 1:10, 2:3)  881.381  920.3695  989.1439  956.7870 1011.452 1380.955   100
     spc_j_DT(sp4, 1:10, 2:3) 1573.848 1683.0550 1761.5464 1722.8060 1819.496 2224.064   100
   spc_j_DT_2(sp4, 1:10, 2:3)  938.231  987.7575 1039.5228 1024.0705 1062.644 1584.036   100
```

The differences between base 2, base 3 and data.table 2 are pretty marginal at this scale. Overall data.table appears about 5-10% slower by all stats -- for order of magnitude of 10^0 / 10^1 profile SPCs. By 100 profiles data.table is ahead.

Another thing to consider is that data.table can probably (?) make better use of e.g. multiple cores. But is that "overkill" for tiny operations invoked behind the scenes that can't be (or aren't) effectively parallelized? I need to play around more with this. 

Finally, are Windows machines able to realize full benefits of data.table? How about ones with crappy real-time scanning? Can we set up a matrix comparison of architectures, number of cores, etc?

---

Original post
I realized the j-index extraction could be made more efficient than base, thus allowing me to use the data.table code even when `aqp_df_class(object) != "data.table"`. There was an extra costly operation in there that was not needed that was the difference between outperforming base or not on smaller collections.

I added a demo in the /misc/aqp2 folder where many of my "big SPC" optimizations were being tested. This shows a significant move towards more performant SPC operations that comes from a better understanding of memory management and use of data.table that I have been working on over past several months.

The following benchmark compares the base (`aggregate`-based) code that I optimized several months ago, the "optional" less efficient DT code, and the new better DT code on a random 100k profile collection [(see demo .R file)](https://github.com/ncss-tech/aqp/compare/dtspcj?expand=1#diff-c2aabeacfa72419607a031ac4c363b69bf54ac3dccfeadec67b1c7b104be971b)

NOTE: these benchmarks do not include any i index subsetting, despite `1:10` as i argument. i-index subsetting is orders of magnitude faster and can be readily accomplished with base.

```
Unit: milliseconds
                                   expr       min        lq      mean    median        uq       max neval
 spc_j_base(hundredthousand, 1:10, 2:3) 1188.0499 1229.9885 1262.2579 1254.0748 1280.6622 1358.5141     5
   spc_j_DT(hundredthousand, 1:10, 2:3)  786.5234  795.5842  810.3728  797.6119  814.2999  857.8445     5
 spc_j_DT_2(hundredthousand, 1:10, 2:3)  389.5375  429.3983  525.6855  432.5545  436.3224  940.6149     5
```
