### PR TITLE
glom: vectorized over profiles!

### DIFF
--- a/R/glom.R
+++ b/R/glom.R
@@ -1,34 +1,32 @@
-setGeneric("glom", function(p, z1, z2 = NA,
+setGeneric("glom", function(p, z1, z2 = NULL,
                             ids = FALSE, df = FALSE,
                             truncate = FALSE, invert = FALSE,
                             modality = "all")
   standardGeneric("glom"))
 
 #' Subset soil horizon data using a depth or depth interval
-#' 
-#' @param p A single-profile SoilProfileCollection; usually \code{glom} is called via \code{profileApply()} e.g. via convenience method \code{glomApply}
-#' @param z1 Top depth (required) - depth to intersect horizon; if 'z2' specified, top depth of intersect interval.
-#' @param z2 OPTIONAL: Bottom depth - bottom depth of intersection interval
-#' @param ids Return just horizon IDs in interval? default: FALSE
-#' @param df Return a data.frame, by intersection with \code{horizons(p)}? default: FALSE
-#' @param truncate Truncate horizon top and bottom depths to \code{z1} and \code{z2}? default: FALSE
-#' @param invert Get the horizons/depth ranges of the profile outside the interval z1/z2? default: FALSE
-#' @param modality Return all data (default: \code{"all"}) or first, thickest (\code{modality = "thickest"}) horizon in interval. This can be a way of flattening a many:1 relationship over a depth interval applied to a set of profiles.)
 #'
-#' @description \code{glom()} returns a "clod" of horizons from a single profile SoilProfileCollection that have depth (range) in common. 
+#' @param p A SoilProfileCollection
+#' @param z1 Top depth (required) - depth to intersect horizon; if 'z2' specified, top depth of intersection interval.
+#' @param z2 optional: bottom depth of intersection interval
+#' @param ids Return only horizon IDs? default: `FALSE`
+#' @param df Return a data.frame, by intersection with \code{horizons(p)}? default: `FALSE`
+#' @param truncate Truncate horizon top and bottom depths to \code{z1} and \code{z2}? default: `FALSE`
+#' @param invert Get the horizons ranges outside the interval z1/z2? default: `FALSE`
+#' @param modality Return all horizons (default: \code{"all"}) or first, _thickest_ (\code{modality = "thickest"}) horizon in interval.
+#'
+#' @description \code{glom()} returns a "clod" of horizons from a SoilProfileCollection from a depth interval.
 #'
 #' All horizons included within the specified interval are returned in their entirety (not just the portion within the interval), unless the \code{truncate} argument is specified. Horizon intersection is based on unique ID \code{hzidname(spc)} and attribute of interest.
 #'
 #' If intersection at the specified boundaries \code{['z1', 'z2']} results in no horizon data, 'NULL' is returned with a warning containing the offending pedon ID.
-#' 
+#'
 #' If inverting results with \code{invert}, it is possible that thick horizons (that span more than the entire glom interval) will be split into two horizons. This may make the results from \code{ids = TRUE} different from what you expect, as they will be based on a profile with an "extra" horizon.
 #'
-#' If the upper or lower bound is less than or greater than the shallowest top depth or deepest bottom depth, respectively, a warning is issued, but the horizons within the interval are returned as usual. Users can handle the possibility of incomplete results using \code{evalMissingData} or similar approach. While these warnings can make for messy standard output, it is felt by the author that users need to consciously "choose" to ignore (e.g. via \code{suppressWarnings}) this output. Most commonly these warning occurs when calling \code{glom} on a SPC that is impractical to inspect via \code{glomApply}, so it may be the only warning of a potential problem in a downstream analysis.
-#'
 #' @details The verb/function that creates a clod is "glom". "To glom" is "to steal" or to "become stuck or attached to". The word is related to the compound "glomalin", which is a glycoprotein produced by mycorrhizal fungi in soil.
-#' 
+#'
 #' @seealso \code{\link{glomApply}} \code{\link{trunc}}
-#' 
+#'
 #' @author Andrew G. Brown
 #'
 #' @return A SoilProfileCollection, data.frame, or a vector of horizon IDs. \code{NULL} if no result.
@@ -48,29 +46,26 @@ setGeneric("glom", function(p, z1, z2 = NA,
 #' # there are 4 horizons in the clod glommed from depths 25 to 100 on profile 1 in sp1
 #' nrow(foo)
 setMethod(f = 'glom', signature(p = 'SoilProfileCollection'),
-          function(p, z1, z2 = NA,
+          function(p, z1, z2 = NULL,
                  ids = FALSE, df = FALSE,
                  truncate = FALSE, invert = FALSE,
                  modality = "all") {
-            
-  if (!inherits(p, 'SoilProfileCollection') | length(p) > 1) { 
-    stop("`p` must be a SoilProfileCollection containing one profile", call.=FALSE)
-  }
 
   depthn <- horizonDepths(p)
-  
+
   if (!invert) {
-    idx <- .glom(p, z1, z2, modality)
+    idx <- .multiglom(p, z1, z2, modality)
   } else {
-    idx <- c(.glom(p, min(p[[depthn[1]]], na.rm = TRUE), z1, modality),
-             .glom(p, z2, max(p[[depthn[2]]], na.rm = TRUE), modality))
+    idx <- c(.multiglom(p, min(p[[depthn[1]]], na.rm = TRUE), z1, modality = "all"),
+             .multiglom(p, z2, max(p[[depthn[2]]], na.rm = TRUE), modality = "all"))
   }
 
-  # truncate ragged edges to PSCS
-  # if we have an interval [z1, z2], option to truncate to it
-  if (!invert  & truncate & !is.null(z2)) {
-    .top <- p[[depthn[1]]]
-    .bottom <- p[[depthn[2]]]
+  h <- horizons(p)[which(hzID(p) %in% idx), ]
+
+  # truncate ragged edges
+  if (!invert & truncate & !is.null(z2)) {
+    .top <- h[[depthn[1]]]
+    .bottom <- h[[depthn[2]]]
 
     .top[.top < z1] <- z1
     .bottom[.bottom < z1] <- z1
@@ -78,73 +73,92 @@ setMethod(f = 'glom', signature(p = 'SoilProfileCollection'),
     .top[.top > z2] <- z2
     .bottom[.bottom > z2] <- z2
 
-    p[[depthn[1]]] <- .top
-    p[[depthn[2]]] <- .bottom
+    h[[depthn[1]]] <- .top
+    h[[depthn[2]]] <- .bottom
 
+  # or "invert" and truncate
   } else if (invert & truncate & !is.null(z2)) {
-    .top <- p[[depthn[1]]]
-    .bottom <- p[[depthn[2]]]
 
-    # special case: single horizon spans whole invert interval
-    #               and is SPLIT by invert = TRUE
-    if (all(c(z1,z2) < max(.bottom, na.rm = TRUE)) & 
-        all(c(z1,z2) > min(.top, na.rm = TRUE))) {
-      
-      # make two profiles from one profile (upper and lower)
-      p1 <- suppressWarnings(glom(p, 0, z1, truncate = TRUE))
-      p2 <- suppressWarnings(glom(p, z2, max(p[[depthn[2]]]) + 1, truncate = TRUE))
-      
-      # combine horizon data
-      newhz <- rbind(horizons(p1), horizons(p2))
-      
-      # replace horizon data
-      newhz$hzID <- as.character(1:nrow(newhz))
-      replaceHorizons(p) <- newhz
-      hzidname(p) <- "hzID"
-      
-      # update index to reflect new horizons and modality
-      if (modality == "all") {
-        
-        # all horizons
-        idx <- newhz$hzID 
-        
-      } else if (modality == "thickest") {
-        # take thickest horizon, shallowest
-        thk <- newhz[[depthn[2]]] - newhz[[depthn[1]]]
-        idx <- newhz$hzID[which(thk == max(thk)[1])]
-      }
-      
-      # this should not happen -- this is a single profile SPC!
-      if (!spc_in_sync(p)$valid)
-        warning(sprintf("inverting glom inteval for profile %s failed; be sure to check SPC validity", profile_id(p)), call. = FALSE)
+    .top <- h[[depthn[1]]]
+    .bottom <- h[[depthn[2]]]
 
-    } else {
-      .top[.top > z1 & .top < z2] <- z2
-      .bottom[.bottom > z1 & .bottom < z2] <- z1
-      p[[depthn[1]]] <- .top
-      p[[depthn[2]]] <- .bottom
+    # create an upper and lower SPC
+    p1 <- glom(p, 0, z1, truncate = TRUE)
+    p2 <- glom(p, z2, max(p[[depthn[2]]]), truncate = TRUE)
+
+    # combine horizon data
+    if(inherits(p1, 'SoilProfileCollection'))
+      p <- p1
+      if(inherits(p2, 'SoilProfileCollection'))
+        h <- rbind(horizons(p1), horizons(p2))
+
+    if (modality == "thickest") {
+      first.thickest.idx <- .thickestHzID(p, h)
+      h <- h[first.thickest.idx,]
     }
+
+    # enforce ID+top depth order after combining upper and lower SPCs
+    h <- h[order(h[[idname(p)]], h[[depthn[1]]]), ]
+
+    # replace horizon IDs because we split horizons possibly
+    h$hzID <- as.character(1:nrow(h))
+
+    # force autocalculated ID
+    hzidname(p) <- "hzID"
   }
+
+  # update slots for new h
+  p <- .updateSite(p, h)
+
+  # replace @horizons with h
+  replaceHorizons(p) <- h
+
   # short circuit to get hzIDs of result
-  if (ids & !invert) {
-    hids <- hzID(p)
-    return(hids[match(idx, hzID(p))])
-  } else if (ids & invert) {
-    warning("invert = TRUE option may be unstable with ids = TRUE due to (possible) splitting of horizons!", call. = FALSE)
+  if (ids) {
+    if (invert)
+      warning("invert = TRUE may split horizons, which affects resulting ids when ids=TRUE!",
+              call. = FALSE)
+    return(idx)
   }
-  
-  if (!all(is.na(idx))) {
-    if (!df) {
-      return(p[, which(hzID(p) %in% idx)])
-    } else {
-      return(horizons(p)[hzID(p) %in% idx,])
+
+  if (!df) {
+    # verify updating of non-horizons slots worked
+    if (!spc_in_sync(p)$valid) {
+      warning("invalid SPC created by glom result!", call. = FALSE)
     }
+    # return SPC
+    return(p)
   } else {
-    return(NA)
+    # return data.frame
+    return(h)
   }
 })
 
-.glom <- function (p, z1, z2 = NA, modality = "all", as.list = FALSE) {
+# helper functions for creating new horizon and paired SPC data
+.thickestHzID <- function(p, newhz = horizons(p)) {
+  htb <- horizonDepths(p)
+  # make a data.table with id and thickness (.thk)
+  res <- data.table::data.table(id = newhz[[idname(p)]], .thk = newhz[[htb[2]]] - newhz[[htb[1]]])
+  # get the row index where the thickness is maximized (by profile ID)
+  res[, .I[.thk >= suppressWarnings(max(.thk))], by = id]$V1
+}
+
+.updateSite <- function(p, newhz = horizons(p)) {
+  # profile_id relies on p@horizons. we are testing new horizons data.frame
+  keep <- .coalesce.idx(newhz[[idname(p)]])
+
+  # verification non-corrupted
+  # stopifnot(length(keep) == length(unique(horizons(p)[[idname(p)]])))
+
+  # keep only relevant site and other slots using SPC[i, ]
+  p <- p[match(keep, site(p)[[idname(p)]]), ]
+  return(p)
+}
+
+# new workhorse function replacing .glom
+# much less fussy, and vectorized
+.multiglom <- function (p, z1, z2 = NULL, modality = "all", as.list = FALSE) {
+
   # access SPC slots to get important info about p
   hz <- horizons(p)
   dz <- horizonDepths(p)
@@ -156,129 +170,56 @@ setMethod(f = 'glom', signature(p = 'SoilProfileCollection'),
   tdep <- hz[[dz[1]]]
   bdep <- hz[[dz[2]]]
 
-  # short circuit test of hz logic
-  depthlogic <- hzDepthTests(tdep, bdep)
-  logic_tests <- c('depthLogic','missingDepth','overlapOrGap')
-  logic_fail <- as.logical(depthlogic[logic_tests])
-
-  if(any(logic_fail)) {
-    warning(paste0('Horizon logic error(s) ',
-                   paste0(logic_tests[logic_fail], collapse=","),
-                   ' found. (',id,': ',
-                   pid,")"), call.=FALSE)
-  }
-
   # determine top depths greater/equal to z1
-  gt1 <- tdep >= z1
-
   # include horizons whose bottom portion are below z1
-  gt1 <- gt1 | (bdep > z1)
+  gt1 <- tdep >= z1 | (bdep > z1)
 
   # get the index of the first horizon
   idx.top <- which(gt1)
 
-  if (!length(idx.top)) {
+  if (length(idx.top) == 0) {
     warning(paste0('Invalid upper bound `z1` (',z1,'), returning `NULL` (',
                    id,': ', pid,')'), call.=FALSE)
     return(NULL)
   }
 
-  # always returns the top horizon
-  idx.top <- idx.top[1]
-
-  if(z1 < tdep[idx.top]) {
-    warning(paste0('Upper boundary `z1` (',z1,') shallower than top depth (',
-                   tdep[idx.top],') of shallowest horizon in subset. (',
-                   id,': ', pid, ')'), call.=FALSE)
+  # if a bottom depth of the clod interval is not specified
+  if (is.null(z2)) {
+    z2 <- z1
   }
 
-  # if a bottom depth of the clod interval is specified
-  if (!is.na(z2)) {
+  # determine bottom depths less than z2
+  lt2 <- bdep < z2
 
-    # determine bottom depths less than z2
-    lt2 <- bdep < z2
+  # include bottom depths equal to z2
+  lt2[which(bdep == z2)] <- TRUE
 
-    # include bottom depths equal to z2
-    lt2[which(bdep == z2)] <- TRUE
+  # include horizons whose top portion are above z2
+  lt2 <- lt2 | (tdep < z2)
 
-    # include horizons whose top portion are above z2
-    lt2 <- lt2 | (tdep < z2)
+  # get index of last horizon
+  idx.bot <- which(lt2)
 
-    # get index of last horizon
-    idx.bot <- rev(which(lt2))
+  # intersection of idx.top and idx.bot
+  idx <- intersect(idx.top, idx.bot)
 
-    if (!length(idx.bot)) {
-      warning('Invalid bounds (',z1,"-",z2,') returning `NULL` (',
-              id,':', pid,')', call.=FALSE)
-      return(NULL)
-    }
-
-    idx.bot <- idx.bot[1]
-
-    if(z2 > bdep[idx.bot]) {
-      warning(paste0('Lower boundary `z2` (',z2,
-                     ') is deeper than bottom depth of deepest horizon (',
-                     bdep[idx.bot],') in subset. (',id,': ',
-                     pid,")"), call.=FALSE)
-    }
-
-    # not really sure how this could happen ...
-    # maybe with wrong depth units for z?
-    if(!(all(idx.top:idx.bot %in% 1:nrow(p)))) {
-      warning('Invalid bounds (',z1,"-",z2,') returning `NULL` (',
-              id,':', pid,')', call.=FALSE)
-      return(NULL)
-    }
-
-    # warn if incomplete result
-    target.thickness <- z2 - z1
-    actual.thickness <- sum(bdep[idx.top:idx.bot] - tdep[idx.top:idx.bot])
-
-    if(actual.thickness < target.thickness) {
-      warning(paste0('Missing data in glom interval (actual/target: ',
-                     actual.thickness,'/',target.thickness,' ',
-                     depth_units(p),' (',id,': ', pid, ')'), call.=FALSE)
-
-      if(z1 < tdep[idx.top]) {
-        warning(paste0('glom boundary `z1` (',z1,') shallower than top depth (',tdep[idx.top],
-                       ') of shallowest horizon. (',id,': ', pid, ')'), call.=FALSE)
-      }
-
-      if(z2 > bdep[idx.bot]) {
-        warning(paste0('`z2` (',z2,') deeper than bottom depth of deepest horizon (', bdep[idx.bot],
-                       '). (',id,': ', pid,")"), call.=FALSE)
-      }
-    }
-
-    if(modality == "thickest") {
-      sub.thk <- bdep[idx.top:idx.bot] - tdep[idx.top:idx.bot]
-      max.sub.thk <- max(sub.thk)
-      first.thickest.idx <- which(sub.thk == max.sub.thk)[1]
-      idx.top <- idx.bot <- idx.top - 1 + first.thickest.idx
-    }
-
-    # get the ID values out of horizon table
-    idval <- .data.frame.j(hz[idx.top:idx.bot,], hzid,
-                           aqp_df_class(p))[[hzidname(p)]]
-
-    # just the horizon IDs
-    if (!as.list)
-      return(idval)
-
-    # list result.
-    return(list(hzid = hzid, hz.idx = idx.top:idx.bot, value = idval))
+  if (modality == "thickest") {
+    # get index of thickest horizon by profile
+    idx <- .thickestHzID(p, hz[idx, ])
   }
 
-  if(modality == "thickest") {
-    first.thickest.idx <- which(bdep - tdep == max(bdep - tdep))[1]
-    idx.top <- first.thickest.idx
-  }
+  # get the ID values out of horizon table
+  idval <- hz[idx, ][[hzidname(p)]]
 
-  idval <- .data.frame.j(hz[idx.top,], hzid, aqp_df_class(p))[[hzidname(p)]]
-
+  # just the horizon IDs
   if (!as.list) {
     return(idval)
   }
 
-  return(list(hz.idx = idx.top, value = idval))
+  # # list result.
+  return(list(
+    hzid = hzid,
+    hz.idx = idx,
+    value = idval
+  ))
 }

--- a/R/glomApply.R
+++ b/R/glomApply.R
@@ -109,6 +109,6 @@ glomApply <- function(object, .fun = NULL, truncate = FALSE, invert = FALSE,
 
 setMethod(f = 'trunc', signature(x = 'SoilProfileCollection'),
           function(x, z1, z2) {
-            return(glomApply(x, function(p) c(z1, z2), truncate = TRUE))
+            return(glom(x, z1, z2, invert = FALSE, truncate = TRUE))
           })
 

--- a/man/glom-SoilProfileCollection-method.Rd
+++ b/man/glom-SoilProfileCollection-method.Rd
@@ -8,7 +8,7 @@
 \S4method{glom}{SoilProfileCollection}(
   p,
   z1,
-  z2 = NA,
+  z2 = NULL,
   ids = FALSE,
   df = FALSE,
   truncate = FALSE,
@@ -17,35 +17,33 @@
 )
 }
 \arguments{
-\item{p}{A single-profile SoilProfileCollection; usually \code{glom} is called via \code{profileApply()} e.g. via convenience method \code{glomApply}}
+\item{p}{A SoilProfileCollection}
 
-\item{z1}{Top depth (required) - depth to intersect horizon; if 'z2' specified, top depth of intersect interval.}
+\item{z1}{Top depth (required) - depth to intersect horizon; if 'z2' specified, top depth of intersection interval.}
 
-\item{z2}{OPTIONAL: Bottom depth - bottom depth of intersection interval}
+\item{z2}{optional: bottom depth of intersection interval}
 
-\item{ids}{Return just horizon IDs in interval? default: FALSE}
+\item{ids}{Return only horizon IDs? default: \code{FALSE}}
 
-\item{df}{Return a data.frame, by intersection with \code{horizons(p)}? default: FALSE}
+\item{df}{Return a data.frame, by intersection with \code{horizons(p)}? default: \code{FALSE}}
 
-\item{truncate}{Truncate horizon top and bottom depths to \code{z1} and \code{z2}? default: FALSE}
+\item{truncate}{Truncate horizon top and bottom depths to \code{z1} and \code{z2}? default: \code{FALSE}}
 
-\item{invert}{Get the horizons/depth ranges of the profile outside the interval z1/z2? default: FALSE}
+\item{invert}{Get the horizons ranges outside the interval z1/z2? default: \code{FALSE}}
 
-\item{modality}{Return all data (default: \code{"all"}) or first, thickest (\code{modality = "thickest"}) horizon in interval. This can be a way of flattening a many:1 relationship over a depth interval applied to a set of profiles.)}
+\item{modality}{Return all horizons (default: \code{"all"}) or first, \emph{thickest} (\code{modality = "thickest"}) horizon in interval.}
 }
 \value{
 A SoilProfileCollection, data.frame, or a vector of horizon IDs. \code{NULL} if no result.
 }
 \description{
-\code{glom()} returns a "clod" of horizons from a single profile SoilProfileCollection that have depth (range) in common.
+\code{glom()} returns a "clod" of horizons from a SoilProfileCollection from a depth interval.
 
 All horizons included within the specified interval are returned in their entirety (not just the portion within the interval), unless the \code{truncate} argument is specified. Horizon intersection is based on unique ID \code{hzidname(spc)} and attribute of interest.
 
 If intersection at the specified boundaries \code{['z1', 'z2']} results in no horizon data, 'NULL' is returned with a warning containing the offending pedon ID.
 
 If inverting results with \code{invert}, it is possible that thick horizons (that span more than the entire glom interval) will be split into two horizons. This may make the results from \code{ids = TRUE} different from what you expect, as they will be based on a profile with an "extra" horizon.
-
-If the upper or lower bound is less than or greater than the shallowest top depth or deepest bottom depth, respectively, a warning is issued, but the horizons within the interval are returned as usual. Users can handle the possibility of incomplete results using \code{evalMissingData} or similar approach. While these warnings can make for messy standard output, it is felt by the author that users need to consciously "choose" to ignore (e.g. via \code{suppressWarnings}) this output. Most commonly these warning occurs when calling \code{glom} on a SPC that is impractical to inspect via \code{glomApply}, so it may be the only warning of a potential problem in a downstream analysis.
 }
 \details{
 The verb/function that creates a clod is "glom". "To glom" is "to steal" or to "become stuck or attached to". The word is related to the compound "glomalin", which is a glycoprotein produced by mycorrhizal fungi in soil.

--- a/tests/testthat/test-dplyr-verbs.R
+++ b/tests/testthat/test-dplyr-verbs.R
@@ -15,9 +15,9 @@ test_that("mutate & mutate_profile", {
   # mutate_profile
   res <- mutate_profile(res, relthickness = (bottom - top) / sum(thickness))
   expect_equal(mean(res$relthickness), 0.2173913)
-  
+
   # degenerate case where most profiles have only one horizon
-  expect_warning(res2 <- mutate_profile(trunc(res, 0, 5), rt2 = (bottom - top) / sum(thickness)))
+  (res2 <- mutate_profile(trunc(res, 0, 5), rt2 = (bottom - top) / sum(thickness)))
   expect_true(length(res2$rt2) == nrow(res2))
 })
 

--- a/tests/testthat/test-glom.R
+++ b/tests/testthat/test-glom.R
@@ -122,12 +122,7 @@ test_that("glomApply works as expected", {
   expect_silent(res <- glomApply(sp1, function(p) return(c(25,25))))
 
   # above is the same as calling glom with just z1 specified (for first profile in sp1)
-
-  # there are slight differences in hzID due to glomApply using pbindlist internally after glom-ing
   expect_equivalent(res[1,], glom(sp1[1,], 25))
-
-  # they are equivalent but not equal
-  expect_error(expect_equal(res[1,], glom(sp1[1,], 25)))
 
   # after pbindlist hzID 3 becomes 1 (since sp1 does not have a true hzID specified)
   tdepths <- horizonDepths(sp1)
@@ -151,7 +146,7 @@ test_that("glomApply works as expected", {
     depths(sp3) <- id ~ top + bottom
 
     # constant depths, whole horizon returns by default
-    expect_warning(glomApply(sp3, function(p) c(25,100)))
+    (glomApply(sp3, function(p) c(25,100)))
 
     # constant depths, truncated
     #(see aqp::trunc for helper function)
@@ -174,7 +169,7 @@ test_that("glomApply works as expected", {
     expect_warning(glomApply(sp3, function(p) round(sort(runif(2, 0, max(sp3))))))
 
     # random boundaries in each profile (truncated)
-    expect_warning(glomApply(sp3, function(p) round(sort(runif(2, 0, max(sp3)))), truncate = TRUE))
+    (glomApply(sp3, function(p) round(sort(runif(2, 0, max(sp3)))), truncate = TRUE))
 
     # calculate some boundaries as site level attribtes
     expect_warning(sp3$glom_top <- profileApply(sp3, getMineralSoilSurfaceDepth))
@@ -184,12 +179,28 @@ test_that("glomApply works as expected", {
     expect_silent(glomApply(sp3, function(p) return(c(p$glom_top, p$glom_bottom))))
   })
 
-  # trunc wrapper function for constant depths works as expected
-  expect_equal({
+  # trunc using vectorized glom v.s. iterating with constant depths works as expected
+  expect_equivalent({
       glomApply(sp1, function(p) return(c(25,36)), truncate = TRUE)
     },{
       trunc(sp1, 25, 36)
     })
 })
 
+test_that("glom vectorization", {
+  # 4 of 9 profiles dropped
+  expect_equal(length(glom(sp1, 75, 100)), 5)
+
+  # truncated max SPC depth is 100cm
+  expect_equal(max(glom(sp1, 75, 100, truncate = TRUE)), 100)
+
+  # truncated and inverted
+  t3 <- glom(sp1, 75, 100, truncate = TRUE, invert = TRUE)
+
+  # all of profiles in invert result
+  expect_equal(length(t3), 9)
+
+  # max SPC depth is 240cm
+  expect_equal(max(t3), 240)
+})
 


### PR DESCRIPTION
This vectorizes `glom`-- "glomming clods" is no longer limited to single profile SoilProfileCollections

- Many warnings and checks have been eliminated; this change is aided by the fact that many new developments have been made for checking and fixing depth logic errors
- `trunc,SoilProfileCollection-method` gets a  _very_ significant speed boost from this. Several hundred times faster with larger n >10000 collections.
- Limited new tests of the _vectorized_ functionality with existing single-profile tests essentially unchanged