### PR TITLE
Have coordinates<- look for horizon "denormalized" XY before error

### DIFF
--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -408,9 +408,9 @@ setMethod(f = 'show',
             if (nrow(coordinates(object)) == n.profiles) {
               cat('\nSpatial Data:\n')
               show(object@sp@bbox)
-              show(proj4string(object))
+              cat("CRS: ", proj4string(object))
             } else {
-              cat('\nSpatial Data: [EMPTY]\n')
+              cat('\nSpatial Data:\n[EMPTY]\n')
             }
 
           })

--- a/R/SoilProfileCollection-spatial.R
+++ b/R/SoilProfileCollection-spatial.R
@@ -68,8 +68,8 @@ setReplaceMethod("coordinates", "SoilProfileCollection",
   function(object, value) {
 
   # basic sanity check
-  if(!inherits(value, "formula"))
-    stop('invalid formula: ', value, call. = FALSE)
+  if (!inherits(value, "formula"))
+    stop('invalid formula: ', quote(value), call. = FALSE)
   
   fterms <- attr(terms(value),"term.labels")
   
@@ -84,7 +84,7 @@ setReplaceMethod("coordinates", "SoilProfileCollection",
   
   # make sure that "normalization" worked
   if (nrow(mf) != length(object)) {
-    stop("coordinates in horizon data are not unique within site: ", as.character(value), call. = FALSE)
+    stop("coordinates in horizon data are not unique within site: ", quote(value), call. = FALSE)
   }
   
   # test for missing coordinates

--- a/misc/sandbox/findNormalizableVars.R
+++ b/misc/sandbox/findNormalizableVars.R
@@ -1,0 +1,54 @@
+library(aqp, warn = FALSE)
+library(data.table)
+
+# number of random sites
+n <- 10
+
+# make some horizon data with denormalized spatial info
+randomsite <- data.table(
+  id = 1:n,
+  x = runif(n),
+  y = runif(n),
+  aletter = LETTERS[floor(runif(n, 1, 26) + 1)]
+)
+spc <- data.frame(randomsite[,"id"][, 
+                             random_profile(.I), by = id][
+                               randomsite, on = "id"])
+
+depths(spc) <- id ~ top + bottom
+
+# coordinates<- does basic normalization from the model.frame output
+coordinates(spc) <- ~ x + y
+
+# still need to use site<-~ for other variables
+# site(spc) <- ~ aletter
+
+plot(slot(spc, 'sp'))
+
+.findNormalizableVars <- function(object) {
+  h <- horizons(object)
+  horizonNames(object)[sapply(horizonNames(object), function(x)
+    all(aggregate(h[[x]], by = list(h[[idname(object)]]),
+                  function(y) length(unique(y)) == 1)$x))]
+}
+
+.findNormalizableVars_2 <- function(object) {
+  h <- data.table(horizons(object))
+  
+  # copy internal id
+  h$.internalID <- h[[idname(object)]]
+  
+  idx <- apply(h[, lapply(.SD, function(x) length(unique(x))), 
+                 by = .internalID], 
+               MARGIN = 2, 
+               function(y) all(y == 1))
+  
+  # remove internal ID
+  idx <- idx[-1]
+  
+  # lookup in horizon names
+  horizonNames(object)[idx]
+}
+
+bench::mark(.findNormalizableVars(spc),
+            .findNormalizableVars_2(spc))

--- a/tests/testthat/test-DT-tbl.R
+++ b/tests/testthat/test-DT-tbl.R
@@ -138,7 +138,26 @@ res <- lapply(dfclasses, function(use_class) {
 
     # "normalize" (horizon -> site) a site-level attribute
     site(test) <- ~ siteprop
-
+    
+    # new random XY data
+    test$y <- rnorm(length(test))
+    test$x <- rnorm(length(test))
+    test$newx <- denormalize(test, "x")
+    test$newy <- denormalize(test, "y")
+    
+    # promote to spatial works from horizons
+    coordinates(test) <- ~ newx + newy
+    
+    # siteprop removed from horizons
+    # newx should be removed after promotion
+    if (use_class == "tbl_df") {
+      expect_warning(expect_null(horizons(test)$siteprop))
+      expect_warning(expect_null(horizons(test)$newx))
+    } else {
+      expect_null(horizons(test)$siteprop)
+      expect_null(horizons(test)$newx)
+    }
+    
     # check that ids are in order
     expect_equal(profile_id(test), site(test)$id)
 

--- a/tests/testthat/test-DT-tbl.R
+++ b/tests/testthat/test-DT-tbl.R
@@ -148,6 +148,9 @@ res <- lapply(dfclasses, function(use_class) {
     # promote to spatial works from horizons
     coordinates(test) <- ~ newx + newy
     
+    # only formulas are allowed for input value
+    expect_error(coordinates(test) <- "foo")
+    
     # siteprop removed from horizons
     # newx should be removed after promotion
     if (use_class == "tbl_df") {


### PR DESCRIPTION
Thanks @jacobisleib, CT Resource Soil Scientist and one of our ncss-tech aqp users for bringing me an interesting example.

If building an SPC with custom data.frame we start with horizon-level data which we pass to `depths<-` 

We need to ["normalize"](https://en.wikipedia.org/wiki/Denormalization) coordinates with `site(spc) <- ~ formula` before we can use `coordinates(spc) <- ~ formula`. I figure this process of promoting to _SoilProfileCollection_ can be streamlined. 

Common errors relate to misspelled or missing column names. But a case we can handle more intelligently is when the right data are present in `@horizons` but not yet normalized to `@site`. 

### Before

``` r
library(aqp, warn=FALSE)
#> This is aqp 1.29
library(data.table)

# number of random sites
n <- 10

# make some horizon data with denormalized spatial info
randomsite <- data.table(
  id = 1:n,
  x = runif(n),
  y = runif(n),
  aletter = LETTERS[floor(runif(n, 1, 26) + 1)]
)
spc <- data.frame(randomsite[,"id"][, random_profile(.I), by = id][randomsite, on = "id"])

depths(spc) <- id ~ top + bottom
#> converting profile IDs from integer to character

head(horizons(spc))
#>   id id.1 top bottom name        p1        p2         p3         p4         p5
#> 1  1    1   0      6   H1  6.719966 13.769501  -4.549496   3.566425  1.3134492
#> 2  1    1   6     20   H2 10.385912 13.981997 -15.183212 -11.740604 11.9774239
#> 3  1    1  20     46   H3  7.066073  8.613244 -11.046476 -11.985940 -1.4353595
#> 4 10   10   0     19   H1  5.707080 21.983736   3.706950  -7.828149 -1.7379039
#> 5 10   10  19     44   H2 -1.644476 25.155421  -7.990276 -13.920843  0.1023329
#> 6 10   10  44     64   H3  8.820563 28.375378 -12.447079  -8.095767 15.6259027
#>           x         y aletter hzID
#> 1 0.3830045 0.9130943       W    1
#> 2 0.3830045 0.9130943       W    2
#> 3 0.3830045 0.9130943       W    3
#> 4 0.5944928 0.3884184       L    4
#> 5 0.5944928 0.3884184       L    5
#> 6 0.5944928 0.3884184       L    6

coordinates(spc) <- ~ x + y
#> Error in eval(predvars, data, env): object 'x' not found
```

### After:

It is easy enough to "check" the terms specified in the formula, figure out what if any slot they occur in, and handle things for the user without doing an extra `site<-~` call.

``` r
library(aqp, warn=FALSE)
#> This is aqp 1.29
library(data.table)

# number of random sites
n <- 10

# make some horizon data with denormalized spatial info
randomsite <- data.table(
  id = 1:n,
  x = runif(n),
  y = runif(n),
  aletter = LETTERS[floor(runif(n, 1, 26) + 1)]
)
spc <- data.frame(randomsite[,"id"][, random_profile(.I), by = id][randomsite, on = "id"])

depths(spc) <- id ~ top + bottom
#> converting profile IDs from integer to character

# NEW: coordinates<- does basic normalization of the model.frame output on horizon slot
coordinates(spc) <- ~ x + y

# still need to use site<-~ for other variables
#site(spc) <- ~ aletter

# inspect
plot(slot(spc, 'sp'))
```

![](https://i.imgur.com/yQTuDaM.png)

### For further testing:
`.findNormalizableVars`: A function for finding "normalizable" variables-- where for all individual `pedons*variable` combinations unique values of those variables of within profiles / sites is `1`