### PR TITLE
.initSPCfromMF: return 0-length SPC with idcol/hzdepthcols

### DIFF
--- a/R/SoilProfileCollection-setters.R
+++ b/R/SoilProfileCollection-setters.R
@@ -87,6 +87,25 @@ setReplaceMethod("depths", "data.frame",
   return(depth)
 }
 
+.prototypeSPC <- function(idn, hzd) {
+  
+  nuhz <- data.frame(id = character(0), 
+                     hzID = character(0), 
+                     top = numeric(0),
+                     bottom = numeric(0), 
+                     stringsAsFactors = FALSE)
+  colnames(nuhz) <- c(idn, "hzID", hzd)
+  
+  nust <- data.frame(id = character(0), 
+                     stringsAsFactors = FALSE)
+  colnames(nust) <- idn
+  
+  return(SoilProfileCollection(idcol = idn, 
+                               depthcols = hzd,
+                               horizons = nuhz,
+                               site = nust))
+}
+
 ##
 ## initialize SP/SPC objects from a model.frame
 ##
@@ -119,7 +138,7 @@ setReplaceMethod("depths", "data.frame",
           all(is.na(data[[depthcols[2]]]) ))) {
       warning("Dropping profile IDs: ", paste0(iddata, collapse = ","),
               "; all top and/or bottom depths missing!", call. = FALSE)
-      return(SoilProfileCollection())
+      return(.prototypeSPC(nm[1], depthcols))
   }
 
   tdep <- data[[depthcols[1]]]
@@ -134,7 +153,7 @@ setReplaceMethod("depths", "data.frame",
   t12 <- any(iddata != usortid) | hsorttdep
 
   if (is.na(t12)) {
-    return(SoilProfileCollection())
+    return(.prototypeSPC(nm[1], depthcols))
   } else if (t12) {
     ## note: forced character sort on ID -- need to impose some order to check depths
     data <- ditd


### PR DESCRIPTION
Small "fix" or at least drawing attention something I noticed. Comes up if user doesn't check for more than 1 row of data before using `depths<-`.

When a valid formula/column names are given to `depths<-`, but the data result in an empty SPC being produced (e.g. empty data.frame) return a SPC with the slots that the user specified, not the default values stored in `SoilProfileCollection()` constructor (id/top/bottom). 

``` r
library(aqp)
#> This is aqp 1.29

h <- data.frame(pid=1:3, hzdept=rep(0:3,3), hzdepb=rep(1:4,3))
h2 <- h[0,]

depths(h) <- pid ~ hzdept + hzdepb
#> converting profile IDs from integer to character
h
#> SoilProfileCollection with 3 profiles and 12 horizons
#> profile ID: pid  |  horizon ID: hzID 
#> Depth range: 4 - 4 cm
#> 
#> ----- Horizons (6 / 12 rows  |  4 / 4 columns) -----
#>  pid hzID hzdept hzdepb
#>    1    1      0      1
#>    1    2      1      2
#>    1    3      2      3
#>    1    4      3      4
#>    2    5      0      1
#>    2    6      1      2
#> [... more horizons ...]
#> 
#> ----- Sites (3 / 3 rows  |  1 / 1 columns) -----
#>  pid
#>    1
#>    2
#>    3
#> 
#> Spatial Data:
#> [EMPTY]

depths(h2) <- pid ~ hzdept + hzdepb
#> converting profile IDs from integer to character
#> Warning: Dropping profile IDs: ; all top and/or bottom depths missing!
h2
#> SoilProfileCollection with 0 profiles and 0 horizons
#> profile ID: pid  |  horizon ID: hzID 
#> Depth range: NA - NA cm
#> 
#> ----- Horizons (0 / 0 rows  |  4 / 4 columns) -----
#> [1] pid    hzID   hzdept hzdepb
#> <0 rows> (or 0-length row.names)
#> 
#> ----- Sites (0 / 0 rows  |  1 / 1 columns) -----
#> [1] pid
#> <0 rows> (or 0-length row.names)
#> 
#> Spatial Data:
#> [EMPTY]
```

