### PR TITLE
Improved `parseMunsell`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aqp
 Version: 1.30
-Date: 2021-04-14
+Date: 2021-04-20
 Title: Algorithms for Quantitative Pedology
 Authors@R: c(person(given="Dylan", family="Beaudette", role = c("aut", "cre"), email = "dylan.beaudette@usda.gov"), person(given="Pierre", family="Roudier", email="roudierp@landcareresearch.co.nz", role = c("aut", "ctb")), person(given="Andrew", family="Brown", email="andrew.g.brown@usda.gov", role = c("aut", "ctb")))
 Author: Dylan Beaudette [aut, cre], Pierre Roudier [aut, ctb], Andrew Brown [aut, ctb]

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -80,7 +80,9 @@ importFrom(stringr,
   fixed,
   str_c,
   str_split,
-  str_trim
+  str_trim,
+  str_extract_all,
+  str_length
 )
 
 importFrom(sp,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # aqp 1.30 (2021-04-14)
+ * `parseMunsell()` now more robust, c/o P. Roudier
  * `mixMunsell`:
     - new method `exact` for direct conversion of mixture spectra to sRGB or closest Munsell chip (via `spec2Munsell()`)
  * new convenience function `PMS2Munsell()` for converting PMS codes -> closest Munsell chip (https://github.com/ncss-tech/aqp/issues/124)

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -132,6 +132,7 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
 
   # otherwise convert
   res <- munsell2rgb(res$hue, res$value, res$chroma, ...)
+  
   return(res)
 }
 

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -96,15 +96,21 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
     function(mn) {
       # split color into pieces, first at hue[space]value/chroma
       
-      # If the very first character of the munsell string is not numeric 
+      # If the very first character of the Munsell string is not numeric 
       # we throw an error
-      if(is.na(as.numeric(substr(mn, 1, 1)))) stop("Error in the Munsell string")
+      if(is.na(suppressWarnings(as.numeric(substr(mn, 1, 1))))) {
+        # If that letter is not N we stop
+        if ( substr(mn, 1, 1) != "N") {
+          return(data.frame( hue = as.character(NA), value = as.character(NA), chroma = as.character(NA)))
+         }
+      }
       
       # Extract hue number
       hue_number <- str_trim(sub("[A-Z].*", "", mn), side = "both")
       remaining <- substr(mn, str_length(hue_number) + 1, str_length(mn))
       hue_letter <- str_trim(sub("[0-9].*", "", remaining), side = "both") 
       remaining <- substr(remaining, str_length(hue_letter) + 1, str_length(remaining))
+      remaining <- str_trim(remaining, side = "both")
       
       if (is.na(delim)) {
         value_chroma <- unlist(strsplit(remaining, "[:,'/_]"))
@@ -115,7 +121,9 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
       # extract pieces, making sure no white space is left
       hue <- paste0(hue_number, hue_letter)
       value <- str_trim(value_chroma[1], side = "both")
-      chroma <- str_trim(value_chroma[2], side = "both")
+      
+      if (length(value_chroma) == 1) chroma <- str_trim(value_chroma[2], side = "both")
+      else chroma <- ""
       
       data.frame(hue = hue, value = value, chroma = chroma, stringsAsFactors = FALSE)
     }

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -54,14 +54,14 @@
 
 #' @title Parse Munsell Color Notation
 #' 
-#' @description Split Munsell color notation into "hue", "value", and "chroma", with optional conversion to sRGB hex notation, sRGB coordinates, and CIELAB coordinates. Conversion is performed by \code{munsell2rgb}.
+#' @description Split Munsell color notation into "hue", "value", and "chroma", with optional conversion to sRGB hex notation, sRGB coordinates, and CIELAB coordinates. Conversion is performed by [`munsell2rgb`].
 #'
-#' @param munsellColor character vector of Munsell colors (e.g. \code{c('10YR 3/4', '5YR 4/6')})
+#' @param munsellColor character vector of Munsell colors (e.g. `c('10YR 3/4', '5YR 4/6')`)
 #' @param convertColors logical, convert colors to sRGB hex notation, sRGB coordinates, CIELAB coordinates
-#' @param delim optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", amd "/" are supported.
-#' @param ... additional arguments to \code{munsell2rgb}
+#' @param delim optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", and "/" are supported.
+#' @param ... additional arguments to [`munsell2rgb`]
 #'
-#' @return a \code{data.frame} object
+#' @return a `data.frame` object
 #' 
 #' @importFrom stringr str_extract_all str_length str_trim
 #' @export
@@ -81,10 +81,31 @@
 #' 
 #' 
 #' 
-parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
-  # sanity check:
-  if(all(is.na(munsellColor)) | all(is.null(munsellColor)) | all(munsellColor == ''))
-    return(rep(NA, times=length(munsellColor)))
+parseMunsell <- function(munsellColor, convertColors = TRUE, delim = NA, ...) {
+  
+  # empty result set for convertColors = FALSE
+  empty <- data.frame(
+    hue = NA_character_, 
+    value = NA_real_, 
+    chroma = NA_real_, 
+    stringsAsFactors = FALSE
+  )
+  
+  # sanity check: all NA
+  if(all(is.na(munsellColor)) | all(is.null(munsellColor)) | all(munsellColor == '')) {
+    # return empty data.frame for each entry
+    if(convertColors) {
+      res <- empty[rep(1, times = length(munsellColor)), ]
+      row.names(res) <- NULL
+      return(res)
+      
+    } else {
+      # return NA for each entry
+      res <- rep(NA, times = length(munsellColor))
+      return()
+    }
+  }
+    
   
   # ensure colours are all upper case
   munsellColor <- toupper(munsellColor)
@@ -93,14 +114,23 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
   res <- lapply(
     munsellColor,
     function(mn) {
+      
+      # NA handling: return empty DF template
+      if(is.na(mn)) {
+        return(empty)
+      }
+      
+      ## TODO: parse hues directly from regex pattern of possible values
+      ##       ---> see parseOSD for those patterns
+      
       # split color into pieces, first at hue[space]value/chroma
       
       # If the very first character of the Munsell string is not numeric 
-      # we throw an error
+      # return empty DF template
       if(is.na(suppressWarnings(as.numeric(substr(mn, 1, 1))))) {
         # If that letter is not N we stop
         if ( substr(mn, 1, 1) != "N") {
-          return(data.frame( hue = as.character(NA), value = as.character(NA), chroma = as.character(NA), stringsAsFactors = FALSE))
+          return(empty)
          }
       }
       
@@ -121,17 +151,30 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
       hue <- paste0(hue_number, hue_letter)
       value <- str_trim(value_chroma[1], side = "both")
       
-      if (length(value_chroma) == 2) chroma <- str_trim(value_chroma[2], side = "both")
-      else chroma <- ""
+      if (length(value_chroma) == 2) {
+        chroma <- str_trim(value_chroma[2], side = "both")
+      } else {
+        chroma <- ""
+      }
       
-      data.frame(hue = hue, value = value, chroma = chroma, stringsAsFactors = FALSE)
+      d <- data.frame(
+        hue = hue, 
+        value = value, 
+        chroma = chroma, 
+        stringsAsFactors = FALSE
+      )
+      
+      return(d)
     }
   )
   
   res <- do.call(rbind, res)
+  row.names(res) <- NULL
   
   # parse, without conversion to numeric / munsell
-  if(convertColors == FALSE) return(res)
+  if(convertColors == FALSE) {
+    return(res)
+  }
 
   # otherwise convert
   res <- munsell2rgb(res$hue, res$value, res$chroma, ...)

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -434,20 +434,17 @@ munsell2rgb <- function(the_hue, the_value, the_chroma, alpha = 1, maxColorValue
 	if(length(unique( c(length(the_hue), length(the_value), length(the_chroma)))) != 1)
 		stop('All inputs must be vectors of equal length.')
   
-  ## TODO: depricate this
-  ## plyr <= 1.6 : check to make sure hue is a character
-  if(is.factor(the_hue)) {
-    cat('Notice: converting hue to character\n')
-    the_hue <- as.character(the_hue)
-  }
-
-
-  # This is a hack to avoid munsell2rgb: "no visible binding for global variable munsell" at package R CMD check
-  munsell <- NULL
-
+  # hue should be character
+  the_hue <- as.character(the_hue)
+  
+  # value and chroma should be numeric
+  the_value <- as.numeric(the_value)
+  the_chroma <- as.numeric(the_chroma)
+  
   # note: this is incompatible with LazyData: true
   # load look-up table from our package
   # This should be moreover more foolproof than data(munsell) c/o PR
+  munsell <- NULL
   load(system.file("data/munsell.rda", package="aqp")[1])
 
   ## 2016-03-07: "fix" neutral hues

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -66,6 +66,8 @@
 #' @importFrom stringr str_extract_all str_length str_trim
 #' @export
 #'
+#' @author P. Roudier and D.E. Beaudette
+#'
 #' @examples
 #' 
 #' # just sRGB
@@ -77,11 +79,8 @@
 #' # CIELAB only
 #' parseMunsell("10YR 3/5", return_triplets = FALSE, returnLAB = TRUE)
 #' 
-
-## TODO: this will not correctly parse gley
-## TODO: re-write with REGEX for extraction from within other text
-## TODO: return NA for obviously wrong Munsell codes
-
+#' 
+#' 
 parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
   # sanity check:
   if(all(is.na(munsellColor)) | all(is.null(munsellColor)) | all(munsellColor == ''))
@@ -434,10 +433,22 @@ munsell2rgb <- function(the_hue, the_value, the_chroma, alpha = 1, maxColorValue
 	if(length(unique( c(length(the_hue), length(the_value), length(the_chroma)))) != 1)
 		stop('All inputs must be vectors of equal length.')
   
-  # hue should be character
+  # in case of factors, why would anyone do this?
+  if(is.factor(the_hue)) {
+    the_hue <- as.character(the_hue)
+  }
+  if(is.factor(the_value)) {
+    the_value <- as.character(the_value)
+  }
+  if(is.factor(the_chroma)) {
+    the_chroma <- as.character(the_chroma)
+  }
+  
+  # expected data types
+  # hue: character
   the_hue <- as.character(the_hue)
   
-  # value and chroma should be numeric
+  # value and chroma: numeric
   the_value <- as.numeric(the_value)
   the_chroma <- as.numeric(the_chroma)
   
@@ -462,11 +473,11 @@ munsell2rgb <- function(the_hue, the_value, the_chroma, alpha = 1, maxColorValue
   ## temporary fix for #44 (https://github.com/ncss-tech/aqp/issues/44)
   # round non integer value and chroma
   if ( !isTRUE(all.equal(as.character(the_value), as.character(as.integer(the_value)) )) ) {
-    the_value <- round(as.numeric(the_value))
+    the_value <- round(the_value)
     warning("'the_value' has been rounded to the nearest integer.", call. = FALSE)
   }
   if ( !isTRUE(all.equal(as.character(the_chroma), as.character(as.integer(the_chroma)) )) ) {
-    the_chroma <- round(as.numeric(the_chroma))
+    the_chroma <- round(the_chroma)
     warning("'the_chroma' has been rounded to the nearest integer.", call. = FALSE)
   }
   
@@ -475,8 +486,8 @@ munsell2rgb <- function(the_hue, the_value, the_chroma, alpha = 1, maxColorValue
   # note that value / chroma must be same data type as in `munsell` (numeric)
   d <- data.frame(
     hue = the_hue, 
-    value = as.numeric(the_value), 
-    chroma = as.numeric(the_chroma), 
+    value = the_value, 
+    chroma = the_chroma, 
     stringsAsFactors = FALSE
   )
   

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -58,6 +58,7 @@
 #'
 #' @param munsellColor character vector of Munsell colors (e.g. \code{c('10YR 3/4', '5YR 4/6')})
 #' @param convertColors logical, convert colors to sRGB hex notation, sRGB coordinates, CIELAB coordinates
+#' @param delim optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", amd "/" are supported.
 #' @param ... additional arguments to \code{munsell2rgb}
 #'
 #' @return a \code{data.frame} object
@@ -81,7 +82,7 @@
 ## TODO: re-write with REGEX for extraction from within other text
 ## TODO: return NA for obviously wrong Munsell codes
 
-parseMunsell <- function(munsellColor, convertColors=TRUE, ...) {
+parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
   # sanity check:
   if(all(is.na(munsellColor)) | all(is.null(munsellColor)) | all(munsellColor == ''))
     return(rep(NA, times=length(munsellColor)))
@@ -108,7 +109,12 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, ...) {
         stop("Wrong hue string in the Munsell string.", call. = FALSE)
       }
       
-      value_chroma <- unlist(strsplit(hue_split[2], "[:,'/]"))
+      if (is.na(delim)) {
+        value_chroma <- unlist(strsplit(hue_split[2], "[:,'/_]"))
+      } else {
+        value_chroma <- unlist(strsplit(hue_split[2], delim))
+      }
+      
       
       # extract pieces
       hue <- hue_split[1]

--- a/R/munsell2rgb.R
+++ b/R/munsell2rgb.R
@@ -101,7 +101,7 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
       if(is.na(suppressWarnings(as.numeric(substr(mn, 1, 1))))) {
         # If that letter is not N we stop
         if ( substr(mn, 1, 1) != "N") {
-          return(data.frame( hue = as.character(NA), value = as.character(NA), chroma = as.character(NA)))
+          return(data.frame( hue = as.character(NA), value = as.character(NA), chroma = as.character(NA), stringsAsFactors = FALSE))
          }
       }
       
@@ -122,7 +122,7 @@ parseMunsell <- function(munsellColor, convertColors=TRUE, delim = NA, ...) {
       hue <- paste0(hue_number, hue_letter)
       value <- str_trim(value_chroma[1], side = "both")
       
-      if (length(value_chroma) == 1) chroma <- str_trim(value_chroma[2], side = "both")
+      if (length(value_chroma) == 2) chroma <- str_trim(value_chroma[2], side = "both")
       else chroma <- ""
       
       data.frame(hue = hue, value = value, chroma = chroma, stringsAsFactors = FALSE)

--- a/R/soilColorIndices.R
+++ b/R/soilColorIndices.R
@@ -106,9 +106,15 @@ barron.torrent.redness.LAB <- function(hue, value, chroma) {
 #'   # and derive the parent material from the 150-200cm interval
 #'   p150_200 <- glom(p, 150, 200, truncate = TRUE)
 #'   p150_200$thickness <- p150_200$bottom - p150_200$top
-#'   # mix colors
+#'   
+#'   # subset colors and thickness
 #'   clrs <- na.omit(horizons(p150_200)[,c('matrix_color_munsell','thickness')])
-#'   mixMunsell(clrs$matrix_color_munsell, w = clrs$thickness)$munsell
+#'   
+#'   # simulate a subtractive mixture using thickness as weight
+#'   mixMunsell(
+#'   clrs$matrix_color_munsell, 
+#'   w = clrs$thickness, 
+#'   mixingMethod = 'exact')$munsell
 #' })
 #'
 #' # segment profile into 1cm slices (for proper depth weighting)
@@ -140,7 +146,7 @@ barron.torrent.redness.LAB <- function(hue, value, chroma) {
 #' abline(h = c(0,100,150,200), lty = 2)
 #'
 #' # Add [estimated] parent material color swatches
-#' lapply(seq_along(jacobs2000$c_horizon_color), function(i) {
+#' trash <- sapply(seq_along(jacobs2000$c_horizon_color), function(i) {
 #'   rect(i - 0.15, 250, i + 0.15, 225,
 #'        col = parseMunsell(jacobs2000$c_horizon_color[jacobs2000$rubiforder[i]]))
 #' })

--- a/man/harden.rubification.Rd
+++ b/man/harden.rubification.Rd
@@ -37,9 +37,15 @@ jacobs2000$c_horizon_color <- profileApply(jacobs2000, function(p) {
   # and derive the parent material from the 150-200cm interval
   p150_200 <- glom(p, 150, 200, truncate = TRUE)
   p150_200$thickness <- p150_200$bottom - p150_200$top
-  # mix colors
+  
+  # subset colors and thickness
   clrs <- na.omit(horizons(p150_200)[,c('matrix_color_munsell','thickness')])
-  mixMunsell(clrs$matrix_color_munsell, w = clrs$thickness)$munsell
+  
+  # simulate a subtractive mixture using thickness as weight
+  mixMunsell(
+  clrs$matrix_color_munsell, 
+  w = clrs$thickness, 
+  mixingMethod = 'exact')$munsell
 })
 
 # segment profile into 1cm slices (for proper depth weighting)
@@ -71,7 +77,7 @@ plotSPC(jacobs2000, axis.line.offset = -1,
 abline(h = c(0,100,150,200), lty = 2)
 
 # Add [estimated] parent material color swatches
-lapply(seq_along(jacobs2000$c_horizon_color), function(i) {
+trash <- sapply(seq_along(jacobs2000$c_horizon_color), function(i) {
   rect(i - 0.15, 250, i + 0.15, 225,
        col = parseMunsell(jacobs2000$c_horizon_color[jacobs2000$rubiforder[i]]))
 })

--- a/man/parseMunsell.Rd
+++ b/man/parseMunsell.Rd
@@ -4,12 +4,14 @@
 \alias{parseMunsell}
 \title{Parse Munsell Color Notation}
 \usage{
-parseMunsell(munsellColor, convertColors = TRUE, ...)
+parseMunsell(munsellColor, convertColors = TRUE, delim = NA, ...)
 }
 \arguments{
 \item{munsellColor}{character vector of Munsell colors (e.g. \code{c('10YR 3/4', '5YR 4/6')})}
 
 \item{convertColors}{logical, convert colors to sRGB hex notation, sRGB coordinates, CIELAB coordinates}
+
+\item{delim}{optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", amd "/" are supported.}
 
 \item{...}{additional arguments to \code{munsell2rgb}}
 }

--- a/man/parseMunsell.Rd
+++ b/man/parseMunsell.Rd
@@ -11,7 +11,7 @@ parseMunsell(munsellColor, convertColors = TRUE, delim = NA, ...)
 
 \item{convertColors}{logical, convert colors to sRGB hex notation, sRGB coordinates, CIELAB coordinates}
 
-\item{delim}{optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", amd "/" are supported.}
+\item{delim}{optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", and "/" are supported.}
 
 \item{...}{additional arguments to \code{munsell2rgb}}
 }

--- a/man/parseMunsell.Rd
+++ b/man/parseMunsell.Rd
@@ -13,13 +13,13 @@ parseMunsell(munsellColor, convertColors = TRUE, delim = NA, ...)
 
 \item{delim}{optional, specify the type of delimiter used between value and chroma parts of the Munsell code. By default ":", ",:, "'", and "/" are supported.}
 
-\item{...}{additional arguments to \code{munsell2rgb}}
+\item{...}{additional arguments to \code{\link{munsell2rgb}}}
 }
 \value{
 a \code{data.frame} object
 }
 \description{
-Split Munsell color notation into "hue", "value", and "chroma", with optional conversion to sRGB hex notation, sRGB coordinates, and CIELAB coordinates. Conversion is performed by \code{munsell2rgb}.
+Split Munsell color notation into "hue", "value", and "chroma", with optional conversion to sRGB hex notation, sRGB coordinates, and CIELAB coordinates. Conversion is performed by \code{\link{munsell2rgb}}.
 }
 \examples{
 

--- a/man/parseMunsell.Rd
+++ b/man/parseMunsell.Rd
@@ -32,4 +32,9 @@ parseMunsell("10YR 3/5", return_triplets = TRUE, returnLAB = TRUE)
 # CIELAB only
 parseMunsell("10YR 3/5", return_triplets = FALSE, returnLAB = TRUE)
 
+
+
+}
+\author{
+P. Roudier and D.E. Beaudette
 }

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -40,6 +40,12 @@ test_that("parsing Munsell notation", {
   # splitting of text into colums within data.frame
   expect_identical(x.p, data.frame(hue = "10YR", value = "3", chroma = "4", stringsAsFactors = FALSE))
 
+  # Test not using spaces
+  expect_equal(suppressWarnings(parseMunsell('2.5YR 3/4')), suppressWarnings(parseMunsell('2.5YR3/4')))
+  
+  # Test different delimeters
+  expect_equal(suppressWarnings(parseMunsell('2.5YR 3/4')), suppressWarnings(parseMunsell('2.5YR 3_4', delim = "_")))
+  expect_equal(suppressWarnings(parseMunsell('2.5YR 3/4')), suppressWarnings(parseMunsell('2.5YR 3_4')))
 })
 
 

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -36,7 +36,7 @@ test_that("parsing Munsell notation", {
   # neutral colors
   expect_true(inherits(parseMunsell('N 2/', convertColors = FALSE), 'data.frame'))
 
-  # splitting of text into colums within data.frame
+  # splitting of text into columns within data.frame
   expect_identical(x.p, data.frame(hue = "10YR", value = "3", chroma = "4", stringsAsFactors = FALSE))
 
   # Test not using spaces

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -22,17 +22,27 @@ test_that("parseMunsell()", {
 
   # parsing bogus notation generates NA
   # will also generate a warning from munsell2rgb()
-  expect_equal(suppressWarnings(parseMunsell('10YZ 4/5')), as.character(NA))
-  expect_equal(suppressWarnings(parseMunsell('10YR /5')), as.character(NA))
-  expect_equal(suppressWarnings(parseMunsell('10YR ')), as.character(NA))
-  expect_equal(suppressWarnings(parseMunsell('10YR 4/')), as.character(NA))
-  expect_equal(suppressWarnings(parseMunsell('G1 6/N')), as.character(NA))
+  expect_equal(suppressWarnings(parseMunsell('10YZ 4/5')), NA_character_)
+  expect_equal(suppressWarnings(parseMunsell('10YR /5')), NA_character_)
+  expect_equal(suppressWarnings(parseMunsell('10YR ')), NA_character_)
+  expect_equal(suppressWarnings(parseMunsell('10YR 4/')), NA_character_)
+  expect_equal(suppressWarnings(parseMunsell('G1 6/N')), NA_character_)
 
   # parsing bogus notation without conversion
   bogus <- parseMunsell('G1 3/X', convertColors = FALSE)
-  expect_equal(bogus$hue, as.character(NA))
-  expect_equal(bogus$value, as.character(NA))
+  expect_equal(bogus$hue, NA_character_)
+  expect_equal(bogus$value, NA_real_)
+  expect_equal(bogus$chroma, NA_real_)
 
+  # test NA
+  some.NA <- parseMunsell(c(NA, '10YR 3/3'))
+  expect_true(inherits(some.NA, 'character'))
+  expect_true(length(some.NA) == 2)
+  
+  some.NA <- parseMunsell(c(NA, '10YR 3/3'), convertColors = FALSE)
+  expect_true(inherits(some.NA, 'data.frame'))
+  expect_true(nrow(some.NA) == 2)
+  
   # neutral colors
   expect_true(inherits(parseMunsell('N 2/', convertColors = FALSE), 'data.frame'))
 

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -29,10 +29,9 @@ test_that("parsing Munsell notation", {
   expect_equal(suppressWarnings(parseMunsell('G1 6/N')), as.character(NA))
 
   # parsing bogus notation without conversion
-  # doesn't replace with NA
   bogus <- parseMunsell('G1 3/X', convertColors = FALSE)
-  expect_equal(bogus$hue, 'G1')
-  expect_equal(bogus$value, '3')
+  expect_equal(bogus$hue, as.character(NA))
+  expect_equal(bogus$value, as.character(NA))
 
   # neutral colors
   expect_true(inherits(parseMunsell('N 2/', convertColors = FALSE), 'data.frame'))

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -52,7 +52,7 @@ test_that("parseMunsell()", {
   # Test not using spaces
   expect_equal(suppressWarnings(parseMunsell('2.5YR 3/4')), suppressWarnings(parseMunsell('2.5YR3/4')))
   
-  # Test different delimeters
+  # Test different delimiters
   expect_equal(suppressWarnings(parseMunsell('2.5YR 3/4')), suppressWarnings(parseMunsell('2.5YR 3_4', delim = "_")))
   expect_equal(suppressWarnings(parseMunsell('2.5YR 3/4')), suppressWarnings(parseMunsell('2.5YR 3_4')))
 })

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -13,12 +13,12 @@ x.back <- rgb2munsell(color = m.rgb, colorSpace = 'LAB', nClosest = 1)
 # using truncated sRGB values
 x.back.trunc <- rgb2munsell(data.frame(r=0.36, g=0.26, b=0.13))
 
-# neutral colors map to shades of grey
+# neutral colors map to shades of gray
 x.neutral <- parseMunsell('N 2/', return_triplets=TRUE)
 
 ## tests
 
-test_that("parsing Munsell notation", {
+test_that("parseMunsell()", {
 
   # parsing bogus notation generates NA
   # will also generate a warning from munsell2rgb()


### PR DESCRIPTION
This PR implements an improved `parseMunsell`, which now can handle less stable munsell notations, eg using other delimiters than `/`, or missing white spaces.

One study case remains to be implemented: `x.neutral <- parseMunsell('N 2/')`, but it should be possible to adapt this code, which essentially splits the munsell string into 3 parts.