### PR TITLE
glom/mollic.thickness.requirement handle NA index case for `invert=TRUE`

### DIFF
--- a/R/mollicEpipedon.R
+++ b/R/mollicEpipedon.R
@@ -42,12 +42,20 @@ mollic.thickness.requirement <- function(p, texcl.attr = guessHzTexClName(p),
   if(length(p) > 1) {
     stop("`p` must be a single-profile SoilProfileCollection")
   }
+  
+  if (nrow(p) == 0) {
+    return(NA)
+  }
 
   # determine boundaries
   # For purposes of identification of minimum thickness of mollic for field descriptions
   #   technically it is not applying the true taxonomic rules b/c it is based on hz desgn
   mss <- getMineralSoilSurfaceDepth(p)
 
+  if (is.na(mss)) {
+    return(NA)
+  }
+  
   soil_depth <- minDepthOf(p, "Cr|R|Cd|m",
                          no.contact.depth = 200,
                          no.contact.assigned = NA)

--- a/man/glom-SoilProfileCollection-method.Rd
+++ b/man/glom-SoilProfileCollection-method.Rd
@@ -58,7 +58,7 @@ p <- sp1[1]
 foo <- glom(p, 25, 100)
 
 # there are 4 horizons in the clod glommed from depths 25 to 100 on profile 1 in sp1
-nrow(foo)
+nrow(foo) 
 }
 \seealso{
 \code{\link{glomApply}} \code{\link{trunc}}

--- a/tests/testthat/test-mollic.R
+++ b/tests/testthat/test-mollic.R
@@ -10,13 +10,35 @@ spc <- data.frame(id=1, taxsubgrp = "Lithic Haploxeralfs",
                   m_value  = c(2.5, 3,  3,  4,  NA),
                   m_chroma = c(2,   3,  4,  4,  NA))
 
+spc2 <- structure(list(id = c(1,1,1,1), hzname = c("A", "Bt1", "Bt2", "Bk"), 
+                       hzdept = c(0L, 5L, 16L, 36L), 
+                       hzdepb = c(5L, 16L, 36L, 66L), 
+                       claytotest = c(11L, 30L, 32L, 11L), 
+                       texcl = c("sl", "scl", "scl", "sl"), 
+                       d_value = c(6L, 4L, 4L, 4L, 4L), m_chroma = c(2L, 2L,  3L, 3L)), 
+                  class = "data.frame", row.names = c(NA, -4L))
+
 # promote to SoilProfileCollection
 depths(spc) <- id ~ hzdept + hzdepb
 hzdesgnname(spc) <- 'hzname'
 hztexclname(spc) <- 'texcl'
 
+depths(spc2) <- id ~ hzdept + hzdepb
+hzdesgnname(spc2) <- 'hzname'
+hztexclname(spc2) <- 'texcl'
+
+
 test_that("mollic.thickness.requirement", {
   expect_equal(mollic.thickness.requirement(spc, clay.attr = 'prop'), 18)
   expect_equal(mollic.thickness.requirement(spc,  clay.attr = 'prop', truncate = FALSE), 49 / 3)
   expect_equal(mollic.thickness.requirement(trunc(spc, 0, 9),  clay.attr = 'prop'), 10)
+  
+  # this is a controversial/undefined case:
+  # 
+  #  the Bk is identified as a cambic below an argillic 
+  #  
+  #  so most limiting crit is the bottom depth of cambic: 66/3 = 22 
+  #  rather than 36/3 = 12 truncated to 18 which comes from argillic bottom depth/2nd carbonate upperbound
+  expect_equal(mollic.thickness.requirement(spc2, clay.attr = 'claytotest'), 22)
 })
+


### PR DESCRIPTION
This PR patches a bug that produced an unintended `replaceHorizons<-` error `"profile IDs in replacement are missing from site!"`. This was introduced when `glom` was updated to be vectorized, but I think only affects the single-profile case.

The problem identified in the heuristics for finding cambic horizons and removal of overlapping layers that are identified as part of an argillic. Typically occurred when the result of `glom(..., invert=TRUE)`  only had one part above or below the (inverted) glom interval corresponding to the argillic horizon boundaries.