### PR TITLE
Vectorize `glom`, `depthOf`, `getSurfaceHorizonDepth`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,13 @@
-# aqp 1.30 (2021-05-23)
+# aqp 1.30 (2021-05-30)
  * `plotColorMixture()` will respect "names" attribute of colors-to-mix
  * `parseMunsell()` now more robust, c/o P. Roudier
  * `mixMunsell`:
     - new method `exact` for direct conversion of mixture spectra to sRGB or closest Munsell chip (via `spec2Munsell()`)
  * new convenience function `PMS2Munsell()` for converting PMS codes -> closest Munsell chip (https://github.com/ncss-tech/aqp/issues/124)
  * `glom()` `z1` and `z2` arguments vectorized to allow for profile-specific intervals
- * `depthOf()` can now be applied to multiple profiles. If `length(p) > 1` then result is a _data.frame_ containing profile ID, top or bottom depths and pattern
+   *  `z1` and `z2` support non-standard evaluation based on column names in `siteNames(p)`, and also can take character vector (length 1) with column names in `siteNames(p)`
+ * `depthOf()`, `minDepthOf()`, `maxDepthOf()`, `getSurfaceHorizonDepth()`, `getMineralSoilSurfaceDepth()`, `getPlowLayerDepth()` can now be applied to multiple profiles.
+   *  If the input _SoilProfileCollection_ has more than one profile then result is a _data.frame_ containing profile ID, top or bottom depths, horizon designation and pattern
 
 # aqp 1.29 (2021-04-05)
  * CRAN release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
-# aqp 1.30 (2021-05-04)
+# aqp 1.30 (2021-05-23)
  * `plotColorMixture()` will respect "names" attribute of colors-to-mix
  * `parseMunsell()` now more robust, c/o P. Roudier
  * `mixMunsell`:
     - new method `exact` for direct conversion of mixture spectra to sRGB or closest Munsell chip (via `spec2Munsell()`)
  * new convenience function `PMS2Munsell()` for converting PMS codes -> closest Munsell chip (https://github.com/ncss-tech/aqp/issues/124)
+ * `glom()` `z1` and `z2` arguments vectorized
+ * `depthOf()` can now be applied to multiple profiles. If `length(p) > 1` then result is a _data.frame_ containing profile ID, top or bottom depths and pattern.
 
 # aqp 1.29 (2021-04-05)
  * CRAN release

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,8 @@
  * `mixMunsell`:
     - new method `exact` for direct conversion of mixture spectra to sRGB or closest Munsell chip (via `spec2Munsell()`)
  * new convenience function `PMS2Munsell()` for converting PMS codes -> closest Munsell chip (https://github.com/ncss-tech/aqp/issues/124)
- * `glom()` `z1` and `z2` arguments vectorized
- * `depthOf()` can now be applied to multiple profiles. If `length(p) > 1` then result is a _data.frame_ containing profile ID, top or bottom depths and pattern.
+ * `glom()` `z1` and `z2` arguments vectorized to allow for profile-specific intervals
+ * `depthOf()` can now be applied to multiple profiles. If `length(p) > 1` then result is a _data.frame_ containing profile ID, top or bottom depths and pattern
 
 # aqp 1.29 (2021-04-05)
  * CRAN release

--- a/R/SoilProfileCollection-methods.R
+++ b/R/SoilProfileCollection-methods.R
@@ -326,9 +326,8 @@ setMethod("filter", signature(.data = "SoilProfileCollection"),
             aqp::subset(x = .data, ...)
           })
 
-if (!isGeneric("subsetHz"))
-  setGeneric("subsetHz", function(x, ...)
-    standardGeneric("subsetHz"))
+setGeneric("subsetHz", function(x, ...)
+  standardGeneric("subsetHz"))
 
 #' Subset the horizons in a SoilProfileCollection using logical criteria
 #'

--- a/R/depthOf.R
+++ b/R/depthOf.R
@@ -84,7 +84,8 @@ depthOf <- function(p,
       hzdesgn = hzdesgn,
       no.contact.depth = no.contact.depth,
       no.contact.assigned = no.contact.assigned,
-      na.rm = na.rm
+      na.rm = na.rm,
+      simplify = simplify
     ))
   }
   
@@ -170,23 +171,29 @@ depthOf <- function(p,
                         hzdesgn = guessHzDesgnName(p),
                         no.contact.depth = NULL,
                         no.contact.assigned = NA,
-                        na.rm = TRUE) {
+                        na.rm = TRUE,
+                        simplify = TRUE) {
     
   
   id <- idname(p)
   depthcol <- horizonDepths(p)[ifelse(top, 1, 2)]
   
   # depthOf returns all top or bottom depths of horizons matching `hzdesgn`
-  res <- depthOf(p, pattern, FUN = NULL, top, hzdesgn, no.contact.depth, no.contact.assigned)
+  res <- depthOf(p = p,
+                 pattern = pattern,
+                 FUN = NULL,
+                 top = top,
+                 hzdesgn = hzdesgn,
+                 no.contact.depth = no.contact.depth,
+                 no.contact.assigned = no.contact.assigned,
+                 simplify = simplify)
  
   if (inherits(res, 'data.frame')) {
   # otherwise, return the FUN value)) {
     
     # handle warnings about e.g. no non-missing arguments to FUN
-    suppressWarnings({
-      idx <- data.table::as.data.table(res)[, .I[.SD[[depthcol]] == FUN(.SD[[depthcol]], na.rm = na.rm)],
-                                            by = list(res[[id]]), .SDcols = depthcol]$V1
-    })
+    idx <- data.table::as.data.table(res)[, .I[.SD[[depthcol]] == suppressWarnings(FUN(.SD[[depthcol]], na.rm = na.rm))],
+                                          by = list(res[[id]]), .SDcols = depthcol]$V1
     
     res2 <- res[idx, c(idname(p), hzidname(p), depthcol, hzdesgn, "pattern")]
     
@@ -194,7 +201,7 @@ depthOf <- function(p,
     res2 <- suppressWarnings(FUN(res, na.rm = na.rm))
     
     # if not found, depth is infinite
-    if(is.infinite(res2)) {
+    if (length(p) == 1 && (!is.finite(res2) | is.na(res2))) {
       return(no.contact.assigned)
     }
   }

--- a/R/depthOf.R
+++ b/R/depthOf.R
@@ -15,7 +15,7 @@
 #' @param no.contact.assigned Depth to assign when a contact did not occur.
 #' @param simplify logical. Return single profile results as vector (default: `TRUE`) or `data.frame` (`FALSE`)
 #' @param na.rm logical. Remove `NA`? (default: `TRUE`)
-#' @return A numeric vector containing specified depth(s) of horizons matching a pattern. If `length(p) > 1` then a _data.frame_ containing profile ID, top or bottom depths and pattern.
+#' @return A numeric vector containing specified depth(s) of horizons matching a pattern. If `length(p) > 1` then a _data.frame_ containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
 #'
 #' @author Andrew G. Brown
 #'
@@ -86,6 +86,7 @@ depthOf <- function(p,
   }
   
   id <- idname(p)
+  hid <- hzidname(p)
   hznames <- horizonNames(p)
 
   # if the user has not specified a column containing horizon designations
@@ -121,9 +122,13 @@ depthOf <- function(p,
       return(res)
     }
     
-    dfres <- data.frame(idn = hz.match[[id]], depth = res, pattern = pattern, 
+    dfres <- data.frame(idn = hz.match[[id]], 
+                        hidn = hz.match[[hid]],
+                        depth = res, 
+                        hzname = hz.match[[hzdesgn]],
+                        pattern = pattern, 
                         stringsAsFactors = FALSE)
-    colnames(dfres) <- c(id, depthcol, "pattern")
+    colnames(dfres) <- c(id, hid, depthcol, hzdesgn, "pattern")
     return(dfres)
   }
 
@@ -153,7 +158,7 @@ depthOf <- function(p,
     idx <- data.table::as.data.table(res)[, .I[.SD[[depthcol]] == FUN(.SD[[depthcol]], na.rm = na.rm)],
                                           by = list(res[[id]]), .SDcols = depthcol]$V1
 
-    res2 <- res[idx, c(idname(p), depthcol, "pattern")]
+    res2 <- res[idx, c(idname(p), hzidname(p), depthcol, hzdesgn, "pattern")]
     
   } else {
     res2 <- suppressWarnings(FUN(res, na.rm = na.rm))

--- a/R/depthOf.R
+++ b/R/depthOf.R
@@ -1,21 +1,19 @@
 #' Get top or bottom depths of horizons matching a regular expression pattern
 #'
-#' @description The \code{depthOf} family of functions calculate depth of occurrence of a horizon designation pattern. They are used primarily in the place of complex qualitative or quantitative data that would confirm taxonomic criteria.
-#'
-#' Generally, these functions are used to implement assumptions about relationships between diagnostic properties, features and materials and horizon designations commonly used in the field. Particular assumptions may not apply in all localities and/or data sources. Great care should be taken when inspecting results.
+#' @description The \code{depthOf} family of functions calculate depth of occurrence of a horizon designation pattern, or any other value that can be coerced to character and matched with a regular expression.
 #'
 #' If you need all depths of occurrence for a particular pattern, \code{depthOf} is what you are looking for. \code{minDepthOf} and \code{maxDepthOf} are wrappers around \code{depthOf} that return the minimum and maximum depth. They are all set up to handle missing values and missing "contacts" with the target pattern.
 #'
-#' @param p A single-profile SoilProfileCollection.
-#' @param pattern A regular expression to match in the horizon designation column. See:\code{hzdesgn}
+#' @param p a SoilProfileCollection
+#' @param pattern a regular expression to match in the horizon designation column. See:\code{hzdesgn}
 #' @param FUN a function that returns a single value, and takes argument `na.rm`
-#' @param top Should the top (TRUE) or bottom (FALSE) depth be returned for matching horizons? Default: \code{TRUE}.
-#' @param hzdesgn Column name containing horizon designations. Default: \code{guessHzDesgnName(p)}
-#' @param no.contact.depth Depth to assume that contact did not occur.
-#' @param no.contact.assigned Depth to assign when a contact did not occur.
+#' @param top should the top (TRUE) or bottom (FALSE) depth be returned for matching horizons? Default: \code{TRUE}.
+#' @param hzdesgn column name containing horizon designations. Default: \code{guessHzDesgnName(p)}
+#' @param no.contact.depth depth to assume that contact did not occur.
+#' @param no.contact.assigned depth to assign when a contact did not occur.
 #' @param simplify logical. Return single profile results as vector (default: `TRUE`) or `data.frame` (`FALSE`)
 #' @param na.rm logical. Remove `NA`? (default: `TRUE`)
-#' @return A numeric vector containing specified depth(s) of horizons matching a pattern. If `length(p) > 1` then a _data.frame_ containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
+#' @return a numeric vector containing specified depth(s) of horizons matching a pattern. If `length(p) > 1` then a _data.frame_ containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
 #'
 #' @author Andrew G. Brown
 #'

--- a/R/depthOf.R
+++ b/R/depthOf.R
@@ -15,7 +15,7 @@
 #' @param no.contact.assigned Depth to assign when a contact did not occur.
 #' @param simplify logical. Return single profile results as vector (default: `TRUE`) or `data.frame` (`FALSE`)
 #' @param na.rm logical. Remove `NA`? (default: `TRUE`)
-#' @return A numeric vector containing specified depth(s) of horizons matching a pattern.
+#' @return A numeric vector containing specified depth(s) of horizons matching a pattern. If `length(p) > 1` then a _data.frame_ containing profile ID, top or bottom depths and pattern.
 #'
 #' @author Andrew G. Brown
 #'

--- a/R/depthOf.R
+++ b/R/depthOf.R
@@ -118,20 +118,21 @@ depthOf <- function(p,
   }
 
   # if there are non-NA results, return all of them
-  if (length(res) > 0 & any(!is.na(res))) {
+  if (length(res) > 0 && any(!is.na(res))) {
     
-    # default simplify and SPC length is 1
+    # backwards compatible: simplify=TRUE and SPC length is 1
     if (length(p) == 1 && simplify) {
       return(res)
     }
+    
     subsite <- data.frame(idn = profile_id(p), stringsAsFactors = FALSE) 
-    dfres <- data.table::data.table(idn = hz.match[[id]], 
+    dfres <- data.table::data.table(idn = as.character(hz.match[[id]]), 
                                     hidn = hz.match[[hid]],
                                     depth = res, 
-                                    hzname = hz.match[[hzdesgn]],
-                                    stringsAsFactors = FALSE)[subsite, on="idn"]
+                                    hzname = hz.match[[hzdesgn]])[subsite, on = "idn"]
     colnames(dfres) <- c(id, hid, depthcol, hzdesgn)
     dfres$pattern <- pattern
+    
     return(as.data.frame(dfres))
   }
 

--- a/R/getSurfaceHorizonDepth.R
+++ b/R/getSurfaceHorizonDepth.R
@@ -9,23 +9,15 @@
 #' @param p A single-profile SoilProfileCollection object.
 #' @param pattern Regular expression pattern to match for all horizons to be considered part of the "surface".
 #' @param hzdesgn Column name containing horizon designation. Default: \code{guessHzDesgnName(p)}.
-#'
+#' @param simplify logical. Return single profile results as vector (default: `TRUE`) or `data.frame` (`FALSE`)
 #' @return Returns a numeric value corresponding to the bottom depth of the last horizon matching 'pattern' that is contiguous with other matching horizons up to the soil surface (depth = 0).
 #'
 #' @author Andrew G. Brown
 #'
-#' @aliases getSurfaceHorizon
-#'
 #' @aliases getMineralSoilSurfaceDepth
-#' @usage getMineralSoilSurfaceDepth(p, hzdesgn = guessHzDesgnName(p), pattern = "O")
-#'
 #' @aliases getPlowLayerDepth
-#' @usage getPlowLayerDepth(p, hzdesgn = guessHzDesgnName(p), pattern = "^Ap[^b]*")
 #'
-#' @export getSurfaceHorizonDepth
-#' @export getMineralSoilSurfaceDepth
-#' @export getPlowLayerDepth
-#'
+#' @export 
 #' @examples
 #' library(aqp)
 #' data(sp1, package = 'aqp')
@@ -63,94 +55,187 @@
 #' # matches first Oi horizon with original horizon designations of pedon 2
 #' getMineralSoilSurfaceDepth(q, hzdesgn='name')
 #'
-# getSurfaceHorizonDepth
+getSurfaceHorizonDepth <- function(p, pattern, hzdesgn = guessHzDesgnName(p), simplify = TRUE) {
+  hz <- data.table::as.data.table(horizons(p))
+  depthz <- horizonDepths(p)
+  
+  .FIRST <- NULL
+  .SD <- NULL
+  
+  shallowest.depth <- p[, , .FIRST][[depthz[1]]]
+  
+  .get_contiguous_surface_hz <- function(h, hzdesgn) {
+    # identify horizons matching pattern
+    match.idx <- grepl(h[[hzdesgn]], pattern = pattern)
+    
+    emptyres <- h[1, .SD, .SDcols = c(hzidname(p), depthz[2])] 
+    emptyres[[idname(p)]] <- emptyres[[idname(p)]][1]
+    emptyres[[hzidname(p)]] <- NA_character_
+    emptyres[[depthz[2]]] <- as.double(0)
+    emptyres$pattern <- pattern
+    emptyres$hzdesgn <- hzdesgn
+    
+    # no match? return zero or shallowest top depth (the minimum depth)
+    if (length(which(match.idx)) < 1) {
+      return(emptyres)
+    }
+    
+    # identify surface horizon
+    mod.idx <- c(1, rep(0, length(match.idx) - 1))
+    
+    # identify where matches and surface horizon co-occur
+    # matching horizons get a 1, matching surface horizon gets a 2,
+    #   0s kick us out
+    new.idx <- match.idx + mod.idx
+    
+    who.idx <- numeric(0)
+    # we only have a matching surface if the first value is 2
+    #  (meets both above crit)
+    if (new.idx[1] == 2) {
+      # convert that into logical to identify contiguous matches
+      contig <- new.idx > 0 & new.idx <= 2
+      
+      # calculate difference between contiguous matches/nonmatches
+      dcontig <- diff(as.integer(contig))
+      
+      # max depth is, at first, the bottom depth of last contiguous hz
+      max.idx <- length(contig)
+      
+      if(length(max.idx)) {
+        # if we have a negative change at any depth,
+        #  we have a discontinuity
+        
+        # adjust max index (depth) accordingly
+        if(any(dcontig < 0)) {
+          # take first index of negative dcontig
+          # add one to correct for indexing offset due to diff()
+          max.idx <- which(dcontig < 0)[1] + 1
+        }
+        
+        # return last value from contig
+        # (last contiguous horizon with surface)
+        who.idx <- rev(which(contig[1:max.idx]))[1]
+      }
+    }
+    
+    if (length(who.idx) == 0)
+      return(emptyres)
+    
+    res <- h[who.idx, .SD, .SDcols = c(hzidname(p), depthz[2])] 
+    res[[depthz[2]]] <- as.double(res[[depthz[2]]])
+    res$pattern <- pattern
+    res$hzdesgn <- hzdesgn
+    res
+  }
+  
+  hzids <- list(hz[[idname(p)]])
+  names(hzids) <- idname(p)
+  
+  sitetemplate <- data.table::as.data.table(site(p))[,.SD, .SDcols = idname(p)]
+  sitetemplate[[idname(p)]] <- as.character(sitetemplate[[idname(p)]])
+  hzsub <- hz[, .get_contiguous_surface_hz(.SD, hzdesgn), by = hzids]
+  hzsub[[idname(p)]] <- as.character(hzsub[[idname(p)]])
+  out <- hzsub[sitetemplate, on = idname(p)]
+  
+  # not found
+  lnotfound <- shallowest.depth > out[[depthz[2]]]
+  if (any(lnotfound)) {
+    warning("found %s profiles where pattern did not match and shallowest depth is greater than 0",
+            sum(lnotfound), call. = FALSE)
+  }
+  
+  if(length(p) == 1 && simplify) {
+    return(out[[depthz[2]]])
+  }
+  as.data.frame(out)
+}
 
 # starting from the surface, match patterns to horizon
 # return the last bottom depth of a horizon that is contiguous with surface
 # for instance horizon designations: A1-A2-A3-C-Ab , would return A3 bottom depth
-getSurfaceHorizonDepth <- function (p, pattern, hzdesgn = guessHzDesgnName(p)) {
-
-  # reused variables
-  hz <- horizons(p)
-  depthz <- horizonDepths(p)
-  shallowest.depth <- min(hz[[depthz[1]]], na.rm = TRUE)
-
-  # warning messages for incomplete profiles
-  if (is.infinite(shallowest.depth)) {
-    warning(paste0("Profile (", profile_id(p), ") is missing horizon top depths."), call. = FALSE)
-    return(NA)
-  }
-
-  if (shallowest.depth > 0) {
-    warning(paste0("Profile (", profile_id(p), ") top depth is greater than zero."), call. = FALSE)
-  }
-
-  if (shallowest.depth < 0) {
-    warning(paste0("Profile (", profile_id(p), ") top depth is less than zero."), call. = FALSE)
-  }
-
-  # identify horizons matching pattern
-  match.idx <- grepl(hz[[hzdesgn]], pattern = pattern)
-
-  # no match? return zero or shallowest top depth (the minimum depth)
-  if (length(which(match.idx)) < 1) {
-    return(shallowest.depth)
-  }
-
-  # identify surface horizon
-  mod.idx <- c(1, rep(0, length(match.idx) - 1))
-
-  # identify where matches and surface horizon co-occur
-  # matching horizons get a 1, matching surface horizon gets a 2,
-  #   0s kick us out
-  new.idx <- match.idx + mod.idx
-
-  who.idx <- numeric(0)
-  # we only have a matching surface if the first value is 2
-  #  (meets both above crit)
-  if (new.idx[1] == 2) {
-    # convert that into logical to identify contiguous matches
-    contig <- new.idx > 0 & new.idx <= 2
-
-    # calculate difference between contiguous matches/nonmatches
-    dcontig <- diff(as.integer(contig))
-
-    # max depth is, at first, the bottom depth of last contiguous hz
-    max.idx <- length(contig)
-
-    if(length(max.idx)) {
-      # if we have a negative change at any depth,
-      #  we have a discontinuity
-
-      # adjust max index (depth) accordingly
-      if(any(dcontig < 0)) {
-        # take first index of negative dcontig
-        # add one to correct for indexing offset due to diff()
-        max.idx <- which(dcontig < 0)[1] + 1
-      }
-
-      # return last value from contig
-      # (last contiguous horizon with surface)
-      who.idx <- rev(which(contig[1:max.idx]))[1]
-    }
-  }
-
-  # if no horizons are contiguous with surface return the minimum depth
-  if (!length(who.idx)) {
-    return(shallowest.depth)
-  }
-
-  # get bottom depth from last horizon
-  return(as.numeric(.data.frame.j(hz[who.idx, ], depthz[2], aqp_df_class(p))))
-}
+# getSurfaceHorizonDepth <- function (p, pattern, hzdesgn = guessHzDesgnName(p)) {
+# 
+#   # reused variables
+#   hz <- horizons(p)
+#   depthz <- horizonDepths(p)
+#   shallowest.depth <- min(hz[[depthz[1]]], na.rm = TRUE)
+# 
+#   # warning messages for incomplete profiles
+#   if (is.infinite(shallowest.depth)) {
+#     warning(paste0("Profile (", profile_id(p), ") is missing horizon top depths."), call. = FALSE)
+#     return(NA)
+#   }
+# 
+#   if (shallowest.depth > 0) {
+#     warning(paste0("Profile (", profile_id(p), ") top depth is greater than zero."), call. = FALSE)
+#   }
+# 
+#   if (shallowest.depth < 0) {
+#     warning(paste0("Profile (", profile_id(p), ") top depth is less than zero."), call. = FALSE)
+#   }
+# 
+#   # identify horizons matching pattern
+#   match.idx <- grepl(hz[[hzdesgn]], pattern = pattern)
+# 
+#   # no match? return zero or shallowest top depth (the minimum depth)
+#   if (length(which(match.idx)) < 1) {
+#     return(shallowest.depth)
+#   }
+# 
+#   # identify surface horizon
+#   mod.idx <- c(1, rep(0, length(match.idx) - 1))
+# 
+#   # identify where matches and surface horizon co-occur
+#   # matching horizons get a 1, matching surface horizon gets a 2,
+#   #   0s kick us out
+#   new.idx <- match.idx + mod.idx
+# 
+#   who.idx <- numeric(0)
+#   # we only have a matching surface if the first value is 2
+#   #  (meets both above crit)
+#   if (new.idx[1] == 2) {
+#     # convert that into logical to identify contiguous matches
+#     contig <- new.idx > 0 & new.idx <= 2
+# 
+#     # calculate difference between contiguous matches/nonmatches
+#     dcontig <- diff(as.integer(contig))
+# 
+#     # max depth is, at first, the bottom depth of last contiguous hz
+#     max.idx <- length(contig)
+# 
+#     if(length(max.idx)) {
+#       # if we have a negative change at any depth,
+#       #  we have a discontinuity
+# 
+#       # adjust max index (depth) accordingly
+#       if(any(dcontig < 0)) {
+#         # take first index of negative dcontig
+#         # add one to correct for indexing offset due to diff()
+#         max.idx <- which(dcontig < 0)[1] + 1
+#       }
+# 
+#       # return last value from contig
+#       # (last contiguous horizon with surface)
+#       who.idx <- rev(which(contig[1:max.idx]))[1]
+#     }
+#   }
+# 
+#   # if no horizons are contiguous with surface return the minimum depth
+#   if (!length(who.idx)) {
+#     return(shallowest.depth)
+#   }
+# 
+#   # get bottom depth from last horizon
+#   return(as.numeric(.data.frame.j(hz[who.idx, ], depthz[2], aqp_df_class(p))))
+# }
 
 getMineralSoilSurfaceDepth <-  function(p, hzdesgn = guessHzDesgnName(p), pattern = "O") {
   #assumes OSM is given O designation;
   #TODO: add support for lab-sampled organic measurements
   #      keep organic horizons with andic soil properties
-  return(as.numeric(getSurfaceHorizonDepth(p, hzdesgn = hzdesgn, pattern = pattern)))
+  return(getSurfaceHorizonDepth(p, hzdesgn = hzdesgn, pattern = pattern))
 }
 
 getPlowLayerDepth <- function(p, hzdesgn = guessHzDesgnName(p), pattern = "^Ap[^b]*") {
-  return(as.numeric(getSurfaceHorizonDepth(p, hzdesgn = hzdesgn, pattern = pattern)))
+  return(getSurfaceHorizonDepth(p, hzdesgn = hzdesgn, pattern = pattern))
 }

--- a/R/getSurfaceHorizonDepth.R
+++ b/R/getSurfaceHorizonDepth.R
@@ -1,16 +1,16 @@
 #' Determine thickness of horizons (continuous from surface) matching a pattern
 #'
-#' @description This function is used to find the thickness of arbitrary horizon designations that are continuous from the soil surface (depth = 0).
+#' @description Find the thickness of horizon designations, or any other character patterns, that are continuous from the soil surface (depth = 0 or shallowest depth in profile).
 #'
-#' The horizon designation to match is specified with the regular expression pattern 'pattern'. All horizons matching that pattern, that are continuous from the soil surface, count towards the depth / thickness value that is ultimately returned. For instance: horizon designations: A1-A2-A3-C-Ab , would return A3 bottom depth given \code{pattern = "A"}.
+#' @details The horizon designation to match is specified with the regular expression pattern 'pattern'. All horizons matching that pattern, that are continuous from the soil surface, count towards the depth / thickness value that is ultimately returned. For instance: horizon designations: A1-A2-A3-C-Ab , would return A3 bottom depth given \code{pattern = "^A[1-9]*$"}.
 #'
-#' getSurfaceHorizonDepth is used by getPlowLayerDepth for matching Ap horizons; and, it is used by getMineralSoilSurfaceDepth to find the thickness of O horizons in lieu of lab data.
+#' `getSurfaceHorizonDepth` is used by `getPlowLayerDepth` for matching Ap horizons; and, it is used by `getMineralSoilSurfaceDepth` to find the thickness of O horizons in lieu of lab data.
 #'
-#' @param p A single-profile SoilProfileCollection object.
-#' @param pattern Regular expression pattern to match for all horizons to be considered part of the "surface".
-#' @param hzdesgn Column name containing horizon designation. Default: \code{guessHzDesgnName(p)}.
+#' @param p a SoilProfileCollection
+#' @param pattern a regular expression pattern to match for all horizons to be considered part of the "surface".
+#' @param hzdesgn column name containing horizon designation. Default: \code{guessHzDesgnName(p)}.
 #' @param simplify logical. Return single profile results as vector (default: `TRUE`) or `data.frame` (`FALSE`)
-#' @return Returns a numeric value corresponding to the bottom depth of the last horizon matching 'pattern' that is contiguous with other matching horizons up to the soil surface (depth = 0).
+#' @return a numeric value corresponding to the bottom depth of the last horizon matching 'pattern' that is contiguous with other matching horizons up to the soil surface. If `length(p) > 1` then a _data.frame_ containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
 #'
 #' @author Andrew G. Brown
 #'

--- a/R/glom.R
+++ b/R/glom.R
@@ -98,14 +98,14 @@ setMethod(f = 'glom', signature(p = 'SoilProfileCollection'),
     newhz <- newhz[complete.cases(newhz),]
     
     # truncate upper bounds to z1
-    z1tidx <- newhz[,.I[tdep < z1]]
-    z1bidx <- newhz[,.I[bdep < z1]]
+    z1tidx <- newhz[,.I[newhz$tdep < z1]]
+    z1bidx <- newhz[,.I[newhz$bdep < z1]]
     newhz[z1tidx, 'tdep'] <- newhz[z1tidx, 'z1']
     newhz[z1bidx, 'bdep'] <- newhz[z1bidx, 'z1']
     
     # truncate lower bounds to z2
-    z2tidx <- newhz[,.I[tdep > z2]]
-    z2bidx <- newhz[,.I[bdep > z2]]
+    z2tidx <- newhz[,.I[newhz$tdep > z2]]
+    z2bidx <- newhz[,.I[newhz$bdep > z2]]
     newhz[z2tidx, 'tdep'] <- newhz[z2tidx, 'z2']
     newhz[z2bidx, 'bdep'] <- newhz[z2bidx, 'z2']
 

--- a/man/depthOf.Rd
+++ b/man/depthOf.Rd
@@ -38,7 +38,7 @@ depthOf(
 \item{simplify}{logical. Return single profile results as vector (default: \code{TRUE}) or \code{data.frame} (\code{FALSE})}
 }
 \value{
-A numeric vector containing specified depth(s) of horizons matching a pattern.
+A numeric vector containing specified depth(s) of horizons matching a pattern. If \code{length(p) > 1} then a \emph{data.frame} containing profile ID, top or bottom depths and pattern.
 }
 \description{
 The \code{depthOf} family of functions calculate depth of occurrence of a horizon designation pattern. They are used primarily in the place of complex qualitative or quantitative data that would confirm taxonomic criteria.

--- a/man/depthOf.Rd
+++ b/man/depthOf.Rd
@@ -13,7 +13,7 @@ depthOf(
   top = TRUE,
   hzdesgn = guessHzDesgnName(p),
   no.contact.depth = NULL,
-  no.contact.assigned = NA,
+  no.contact.assigned = NA_real_,
   na.rm = TRUE,
   simplify = TRUE
 )

--- a/man/depthOf.Rd
+++ b/man/depthOf.Rd
@@ -9,16 +9,21 @@
 depthOf(
   p,
   pattern,
+  FUN = NULL,
   top = TRUE,
   hzdesgn = guessHzDesgnName(p),
   no.contact.depth = NULL,
-  no.contact.assigned = NA
+  no.contact.assigned = NA,
+  na.rm = TRUE,
+  simplify = TRUE
 )
 }
 \arguments{
 \item{p}{A single-profile SoilProfileCollection.}
 
 \item{pattern}{A regular expression to match in the horizon designation column. See:\code{hzdesgn}}
+
+\item{FUN}{a function that returns a single value, and takes argument \code{na.rm}}
 
 \item{top}{Should the top (TRUE) or bottom (FALSE) depth be returned for matching horizons? Default: \code{TRUE}.}
 
@@ -27,6 +32,10 @@ depthOf(
 \item{no.contact.depth}{Depth to assume that contact did not occur.}
 
 \item{no.contact.assigned}{Depth to assign when a contact did not occur.}
+
+\item{na.rm}{logical. Remove \code{NA}? (default: \code{TRUE})}
+
+\item{simplify}{logical. Return single profile results as vector (default: \code{TRUE}) or \code{data.frame} (\code{FALSE})}
 }
 \value{
 A numeric vector containing specified depth(s) of horizons matching a pattern.

--- a/man/depthOf.Rd
+++ b/man/depthOf.Rd
@@ -38,7 +38,7 @@ depthOf(
 \item{simplify}{logical. Return single profile results as vector (default: \code{TRUE}) or \code{data.frame} (\code{FALSE})}
 }
 \value{
-A numeric vector containing specified depth(s) of horizons matching a pattern. If \code{length(p) > 1} then a \emph{data.frame} containing profile ID, top or bottom depths and pattern.
+A numeric vector containing specified depth(s) of horizons matching a pattern. If \code{length(p) > 1} then a \emph{data.frame} containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
 }
 \description{
 The \code{depthOf} family of functions calculate depth of occurrence of a horizon designation pattern. They are used primarily in the place of complex qualitative or quantitative data that would confirm taxonomic criteria.

--- a/man/depthOf.Rd
+++ b/man/depthOf.Rd
@@ -19,31 +19,29 @@ depthOf(
 )
 }
 \arguments{
-\item{p}{A single-profile SoilProfileCollection.}
+\item{p}{a SoilProfileCollection}
 
-\item{pattern}{A regular expression to match in the horizon designation column. See:\code{hzdesgn}}
+\item{pattern}{a regular expression to match in the horizon designation column. See:\code{hzdesgn}}
 
 \item{FUN}{a function that returns a single value, and takes argument \code{na.rm}}
 
-\item{top}{Should the top (TRUE) or bottom (FALSE) depth be returned for matching horizons? Default: \code{TRUE}.}
+\item{top}{should the top (TRUE) or bottom (FALSE) depth be returned for matching horizons? Default: \code{TRUE}.}
 
-\item{hzdesgn}{Column name containing horizon designations. Default: \code{guessHzDesgnName(p)}}
+\item{hzdesgn}{column name containing horizon designations. Default: \code{guessHzDesgnName(p)}}
 
-\item{no.contact.depth}{Depth to assume that contact did not occur.}
+\item{no.contact.depth}{depth to assume that contact did not occur.}
 
-\item{no.contact.assigned}{Depth to assign when a contact did not occur.}
+\item{no.contact.assigned}{depth to assign when a contact did not occur.}
 
 \item{na.rm}{logical. Remove \code{NA}? (default: \code{TRUE})}
 
 \item{simplify}{logical. Return single profile results as vector (default: \code{TRUE}) or \code{data.frame} (\code{FALSE})}
 }
 \value{
-A numeric vector containing specified depth(s) of horizons matching a pattern. If \code{length(p) > 1} then a \emph{data.frame} containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
+a numeric vector containing specified depth(s) of horizons matching a pattern. If \code{length(p) > 1} then a \emph{data.frame} containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
 }
 \description{
-The \code{depthOf} family of functions calculate depth of occurrence of a horizon designation pattern. They are used primarily in the place of complex qualitative or quantitative data that would confirm taxonomic criteria.
-
-Generally, these functions are used to implement assumptions about relationships between diagnostic properties, features and materials and horizon designations commonly used in the field. Particular assumptions may not apply in all localities and/or data sources. Great care should be taken when inspecting results.
+The \code{depthOf} family of functions calculate depth of occurrence of a horizon designation pattern, or any other value that can be coerced to character and matched with a regular expression.
 
 If you need all depths of occurrence for a particular pattern, \code{depthOf} is what you are looking for. \code{minDepthOf} and \code{maxDepthOf} are wrappers around \code{depthOf} that return the minimum and maximum depth. They are all set up to handle missing values and missing "contacts" with the target pattern.
 }

--- a/man/getSurfaceHorizonDepth.Rd
+++ b/man/getSurfaceHorizonDepth.Rd
@@ -2,14 +2,16 @@
 % Please edit documentation in R/getSurfaceHorizonDepth.R
 \name{getSurfaceHorizonDepth}
 \alias{getSurfaceHorizonDepth}
-\alias{getSurfaceHorizon}
 \alias{getMineralSoilSurfaceDepth}
 \alias{getPlowLayerDepth}
 \title{Determine thickness of horizons (continuous from surface) matching a pattern}
 \usage{
-getMineralSoilSurfaceDepth(p, hzdesgn = guessHzDesgnName(p), pattern = "O")
-
-getPlowLayerDepth(p, hzdesgn = guessHzDesgnName(p), pattern = "^Ap[^b]*")
+getSurfaceHorizonDepth(
+  p,
+  pattern,
+  hzdesgn = guessHzDesgnName(p),
+  simplify = TRUE
+)
 }
 \arguments{
 \item{p}{A single-profile SoilProfileCollection object.}
@@ -17,6 +19,8 @@ getPlowLayerDepth(p, hzdesgn = guessHzDesgnName(p), pattern = "^Ap[^b]*")
 \item{pattern}{Regular expression pattern to match for all horizons to be considered part of the "surface".}
 
 \item{hzdesgn}{Column name containing horizon designation. Default: \code{guessHzDesgnName(p)}.}
+
+\item{simplify}{logical. Return single profile results as vector (default: \code{TRUE}) or \code{data.frame} (\code{FALSE})}
 }
 \value{
 Returns a numeric value corresponding to the bottom depth of the last horizon matching 'pattern' that is contiguous with other matching horizons up to the soil surface (depth = 0).

--- a/man/getSurfaceHorizonDepth.Rd
+++ b/man/getSurfaceHorizonDepth.Rd
@@ -14,23 +14,24 @@ getSurfaceHorizonDepth(
 )
 }
 \arguments{
-\item{p}{A single-profile SoilProfileCollection object.}
+\item{p}{a SoilProfileCollection}
 
-\item{pattern}{Regular expression pattern to match for all horizons to be considered part of the "surface".}
+\item{pattern}{a regular expression pattern to match for all horizons to be considered part of the "surface".}
 
-\item{hzdesgn}{Column name containing horizon designation. Default: \code{guessHzDesgnName(p)}.}
+\item{hzdesgn}{column name containing horizon designation. Default: \code{guessHzDesgnName(p)}.}
 
 \item{simplify}{logical. Return single profile results as vector (default: \code{TRUE}) or \code{data.frame} (\code{FALSE})}
 }
 \value{
-Returns a numeric value corresponding to the bottom depth of the last horizon matching 'pattern' that is contiguous with other matching horizons up to the soil surface (depth = 0).
+a numeric value corresponding to the bottom depth of the last horizon matching 'pattern' that is contiguous with other matching horizons up to the soil surface. If \code{length(p) > 1} then a \emph{data.frame} containing profile ID, horizon ID, top or bottom depths, horizon designation and pattern.
 }
 \description{
-This function is used to find the thickness of arbitrary horizon designations that are continuous from the soil surface (depth = 0).
+Find the thickness of horizon designations, or any other character patterns, that are continuous from the soil surface (depth = 0 or shallowest depth in profile).
+}
+\details{
+The horizon designation to match is specified with the regular expression pattern 'pattern'. All horizons matching that pattern, that are continuous from the soil surface, count towards the depth / thickness value that is ultimately returned. For instance: horizon designations: A1-A2-A3-C-Ab , would return A3 bottom depth given \code{pattern = "^A[1-9]*$"}.
 
-The horizon designation to match is specified with the regular expression pattern 'pattern'. All horizons matching that pattern, that are continuous from the soil surface, count towards the depth / thickness value that is ultimately returned. For instance: horizon designations: A1-A2-A3-C-Ab , would return A3 bottom depth given \code{pattern = "A"}.
-
-getSurfaceHorizonDepth is used by getPlowLayerDepth for matching Ap horizons; and, it is used by getMineralSoilSurfaceDepth to find the thickness of O horizons in lieu of lab data.
+\code{getSurfaceHorizonDepth} is used by \code{getPlowLayerDepth} for matching Ap horizons; and, it is used by \code{getMineralSoilSurfaceDepth} to find the thickness of O horizons in lieu of lab data.
 }
 \examples{
 library(aqp)

--- a/man/glom-SoilProfileCollection-method.Rd
+++ b/man/glom-SoilProfileCollection-method.Rd
@@ -19,9 +19,9 @@
 \arguments{
 \item{p}{a SoilProfileCollection}
 
-\item{z1}{numeric. (required) top depth to intersect horizon. Either length \code{1} or length equal to \code{length(p)}}
+\item{z1}{numeric vector of top depth to intersect horizon (required). Can be an expression involving \code{siteNames(p)} or quoted column name. Should evaluate to numeric length \code{1} or length equal to \code{length(p)}}
 
-\item{z2}{optional: numeric bottom depth of intersection interval. Either length \code{1}, length equal to \code{length(p)} or \code{NULL}. Default: \code{NULL} is "point" intersection}
+\item{z2}{numeric vector bottom depth of intersection interval (optional). Can also be an expression involving \code{siteNames(p)} or quoted column name. Should evaluate to numeric length \code{1}, length equal to \code{length(p)} or \code{NULL}. Default: \code{NULL} is "point" intersection}
 
 \item{ids}{return only horizon IDs? default: \code{FALSE}}
 
@@ -84,6 +84,19 @@ nrow(p3)
 par(mar = c(1,1,3,1))
 plot(p3, color = "prop", max.depth = 200)
 abline(h = c(25, 100), lty = 2)
+
+## profile-specific interval, using expressions evaluated within sp1@site
+
+# calculate some new site-level variables containing target interval
+sp1$glom_top <- (1:9) * 10
+sp1$glom_bottom <- 10 + sp1$glom_top
+
+# glom evaluates non-standard expressions using siteNames(sp1) column names
+p4 <- glom(sp1, glom_top / 2, glom_bottom * 1.2, truncate = TRUE)
+
+# inspect graphically
+par(mar = c(1,1,3,1))
+plot(p4, color = "prop", max.depth = 200)
 
 }
 \seealso{

--- a/man/glom-SoilProfileCollection-method.Rd
+++ b/man/glom-SoilProfileCollection-method.Rd
@@ -17,48 +17,74 @@
 )
 }
 \arguments{
-\item{p}{A SoilProfileCollection}
+\item{p}{a SoilProfileCollection}
 
-\item{z1}{Top depth (required) - depth to intersect horizon; if 'z2' specified, top depth of intersection interval.}
+\item{z1}{numeric. (required) top depth to intersect horizon. Either length \code{1} or length equal to \code{length(p)}}
 
-\item{z2}{optional: bottom depth of intersection interval}
+\item{z2}{optional: numeric bottom depth of intersection interval. Either length \code{1}, length equal to \code{length(p)} or \code{NULL}. Default: \code{NULL} is "point" intersection}
 
-\item{ids}{Return only horizon IDs? default: \code{FALSE}}
+\item{ids}{return only horizon IDs? default: \code{FALSE}}
 
-\item{df}{Return a data.frame, by intersection with \code{horizons(p)}? default: \code{FALSE}}
+\item{df}{return a data.frame, by intersection with \code{horizons(p)}? default: \code{FALSE}}
 
-\item{truncate}{Truncate horizon top and bottom depths to \code{z1} and \code{z2}? default: \code{FALSE}}
+\item{truncate}{truncate horizon top and bottom depths to \code{z1} and \code{z2}? default: \code{FALSE}}
 
-\item{invert}{Get the horizons ranges outside the interval z1/z2? default: \code{FALSE}}
+\item{invert}{get horizons \emph{outside} the interval \verb{[z1,z2]}? default: \code{FALSE}}
 
-\item{modality}{Return all horizons (default: \code{"all"}) or first, \emph{thickest} (\code{modality = "thickest"}) horizon in interval.}
+\item{modality}{default: \code{"all"} return all horizons; or \code{modality = "thickest"}) to return the \emph{thickest} horizon in interval. If multiple horizons have equal thickness, the first (shallowest) is returned.}
 }
 \value{
-A SoilProfileCollection, data.frame, or a vector of horizon IDs. \code{NULL} if no result.
+a SoilProfileCollection, data.frame, or a vector of horizon IDs. \code{NULL} if no result.
 }
 \description{
-\code{glom()} returns a "clod" of horizons from a SoilProfileCollection from a depth interval.
-
-All horizons included within the specified interval are returned in their entirety (not just the portion within the interval), unless the \code{truncate} argument is specified. Horizon intersection is based on unique ID \code{hzidname(spc)} and attribute of interest.
-
-If intersection at the specified boundaries \code{['z1', 'z2']} results in no horizon data, 'NULL' is returned with a warning containing the offending pedon ID.
-
-If inverting results with \code{invert}, it is possible that thick horizons (that span more than the entire glom interval) will be split into two horizons. This may make the results from \code{ids = TRUE} different from what you expect, as they will be based on a profile with an "extra" horizon.
+Make a "clod" of horizons from a SoilProfileCollection given a point or a depth interval to intersect. The interval \verb{[z1,z2]} may be profile-specific (equal in length to \code{p}), or may be recycled over all profiles (if boundaries are length 1). For "point" intersection, \code{z2} may be left as the default value \code{NULL}.
 }
 \details{
-The verb/function that creates a clod is "glom". "To glom" is "to steal" or to "become stuck or attached to". The word is related to the compound "glomalin", which is a glycoprotein produced by mycorrhizal fungi in soil.
+"To glom" is "to steal" or to "become stuck or attached to". The word is related to the compound "glomalin", which is a glycoprotein produced by mycorrhizal fungi in soil.
+
+The full depth range of horizons included within the interval are returned (a "ragged" SoilProfileCollection) unless the \code{truncate} argument is set as \code{TRUE}. Horizon intersection is based on unique ID \code{hzidname(spc)} and depth range of interest. Profiles that lack data in the range of interest will be dropped from the resulting SoilProfileCollection.
+
+If inverting results with \code{invert}, it is possible that thick horizons (whose boundaries span wider than the specified interval) will be split into \emph{two} horizons, where previously they were one. This may make the results from \code{ids = TRUE} different from what you expect, as they will be based on a profile with an "extra" horizon and re-calculated unique horizon ID (\code{hzidname(spc)}) \code{"hzID"}.
 }
 \examples{
 data(sp1, package = 'aqp')
 depths(sp1) <- id ~ top + bottom
 site(sp1) <- ~ group
 
-p <- sp1[1]
+p <- glom(sp1, 25, 150)
 
-foo <- glom(p, 25, 100)
+# 28 horizons
+nrow(p) 
 
-# there are 4 horizons in the clod glommed from depths 25 to 100 on profile 1 in sp1
-nrow(foo) 
+# inspect graphically
+par(mar = c(1,1,3,1))
+plot(p, color = "prop", max.depth = 200)
+abline(h = c(25, 100), lty = 2)
+
+## glom(..., truncate = TRUE)
+
+p2 <- glom(sp1, 25, 150, truncate = TRUE)
+
+# 28 horizons
+nrow(p2) 
+
+# inspect graphically
+par(mar = c(1,1,3,1))
+plot(p2, color = "prop", max.depth = 200)
+abline(h = c(25, 100), lty = 2)
+
+## glom(..., truncate = TRUE, invert = TRUE)
+
+p3 <- glom(sp1, 25, 150, truncate = TRUE, invert = TRUE)
+
+# 45 horizons
+nrow(p3) 
+
+# inspect graphically
+par(mar = c(1,1,3,1))
+plot(p3, color = "prop", max.depth = 200)
+abline(h = c(25, 100), lty = 2)
+
 }
 \seealso{
 \code{\link{glomApply}} \code{\link{trunc}}

--- a/misc/aqp2/glomDepthOfDemo.R
+++ b/misc/aqp2/glomDepthOfDemo.R
@@ -17,7 +17,7 @@ loafercreek |>
 
 # some new ideas for more functional forms of aqp SPC methods
 .data_dots <- aqp:::.data_dots
-.sliceSPC <- \(x,i) `[`(x,.data_dots(.data, eval(substitute(i)))[[1]])
+.sliceSPC <- \(x,i) `[`(x,.data_dots(compositeSPC(x), eval(substitute(i)))[[1]])
 
 .grepBounds <- function(p, pattern) {
   hzd <- horizonDepths(p)
@@ -45,13 +45,13 @@ loafercreek |>
 }
 
 loafercreek |> 
-  subset(grepl("t", hzname)) |>
+  # subset(grepl("t", hzname)) |>
   .grepBounds("t") |> 
   .niceglom(z1, z2) |> 
   .sliceSPC(1:10) |> 
   plot()
 
-# trying pipebind (=>) 
+# trying pipebind (=>)
 Sys.setenv("_R_USE_PIPEBIND_" = "true")
 loafercreek |>
   subset(grepl("t", hzname)) |>

--- a/misc/aqp2/glomDepthOfDemo.R
+++ b/misc/aqp2/glomDepthOfDemo.R
@@ -1,0 +1,70 @@
+# vectorized glom + depthOf
+library(aqp)
+
+# try with loafercreek
+data(loafercreek, package = "soilDB")
+
+# check data visually first
+loafercreek |> 
+  transform(is_t = grepl('t', hzname)) |> 
+  {\(x, i) `[`(x,i)}(1:10) |> 
+  plot(color = "is_t") 
+
+# inspect depthOf output
+loafercreek |> 
+  depthOf(pattern =  "t") |> 
+  head()
+
+# some new ideas for more functional forms of aqp SPC methods
+.data_dots <- aqp:::.data_dots
+.sliceSPC <- \(x,i) `[`(x,.data_dots(.data, eval(substitute(i)))[[1]])
+
+.grepBounds <- function(p, pattern) {
+  hzd <- horizonDepths(p)
+  p$z1 <- minDepthOf(p, pattern = pattern)[[hzd[1]]]
+  p$z2 <- maxDepthOf(p, pattern = pattern, top = FALSE)[[hzd[2]]]
+  p
+}
+
+.niceglom <- function(p, z1, z2 = NULL,
+                     ids = FALSE, df = FALSE,
+                     truncate = FALSE, invert = FALSE,
+                     modality = "all") {
+  .data <- compositeSPC(p)
+  
+  glom(
+    p,
+    z1 = .data_dots(.data, eval(substitute(z1)))[[1]],
+    z2 = .data_dots(.data, eval(substitute(z2)))[[1]],
+    ids = ids,
+    df = df,
+    truncate = truncate,
+    invert = invert,
+    modality = modality
+  )
+}
+
+loafercreek |> 
+  subset(grepl("t", hzname)) |>
+  .grepBounds("t") |> 
+  .niceglom(z1, z2) |> 
+  .sliceSPC(1:10) |> 
+  plot()
+
+# trying pipebind (=>) 
+Sys.setenv("_R_USE_PIPEBIND_" = "true")
+loafercreek |>
+  subset(grepl("t", hzname)) |>
+  . => {
+    \(x) {
+      hzd <- horizonDepths(x)
+      x$z1 <- minDepthOf(x, pattern = "t")[[hzd[1]]]
+      x$z2 <- maxDepthOf(x, pattern = "t", top = FALSE)[[hzd[2]]]
+      glom(x, x$z1, x$z2)
+    }
+  }(.) |>
+  .sliceSPC(1:10) |> 
+  plot()
+
+
+

--- a/misc/aqp2/multiglomDT.R
+++ b/misc/aqp2/multiglomDT.R
@@ -1,0 +1,69 @@
+# benchmark "old" way
+library(aqp)
+library(microbenchmark)
+
+rnd <- aqp::combine(lapply(1:10000, random_profile, SPC=TRUE))
+n = 1000
+
+rnd_dep <- data.frame(top = round(runif(n, 10, 20)),
+ bottom = round(runif(n, 30, 40)))
+
+system.time(aqp::combine(lapply(
+  1:nrow(rnd_dep), \(i) {
+    glom(rnd[i, ], rnd_dep$top[i], rnd_dep$bottom[i])
+  }
+)))
+
+system.time(glom(rnd[1:n, ], rnd_dep$top, rnd_dep$bottom))
+
+data(loafercreek, package='soilDB')
+
+argillic <- profileApply(loafercreek, 
+                         \(x) data.frame(id = profile_id(x),
+                                         t(getArgillicBounds(x))),
+                         frameify = TRUE)
+
+microbenchmark(\(x) 
+  aqp::combine(lapply(1:nrow(argillic), function(i) 
+    glom(loafercreek[i,], argillic$ubound[i], argillic$lbound[i])))
+)
+
+microbenchmark(\(x) 
+  glom(loafercreek, argillic$ubound, argillic$lbound)
+)
+
+# multiglom data.table testing
+
+plot(glom(loafercreek, argillic$ubound, argillic$lbound))
+
+p <- loafercreek[3:5,]
+z1 <- c(10,20,30)
+z2 <- c(20,30,40)
+modality <- "all"
+truncate <- TRUE
+as.list <- FALSE
+
+# internal method comparisons
+.multiglom <- aqp:::.multiglom
+.multiglomDT <- aqp:::.multiglomDT
+
+# both are vectorized over p
+expect_equal(.multiglom(p, z1[1], z2[1]),
+             .multiglomDT(p, z1[1], z2[1]))
+
+# .multiglomDT is vectorized over z1 and z2 as well as p
+expect_equal(c(.multiglom(p[1, ], z1[1], z2[1]),
+               .multiglom(p[2, ], z1[2], z2[2]),
+               .multiglom(p[3, ], z1[3], z2[3])),
+             .multiglomDT(p, z1, z2))
+
+# alternating z1/z2
+z1 <- c(rep(c(0,55), 5))[1:9]
+z2 <- c(rep(c(10,60), 5))[1:9]
+
+data(sp1)
+depths(sp1) <- id ~ top + bottom
+
+par(mar=c(1,1,3,1))
+plot(sp1, max.depth=60)
+plot(glom(sp1, z1, z2, truncate=TRUE), max.depth=60, add=T, color="prop", name = NA)

--- a/misc/aqp2/multiglomDT.R
+++ b/misc/aqp2/multiglomDT.R
@@ -2,38 +2,56 @@
 library(aqp)
 library(microbenchmark)
 
-rnd <- aqp::combine(lapply(1:10000, random_profile, SPC=TRUE))
-n = 1000
+# number of test profiles
+n <- 1000
 
+# create random 'large' SPC (enough to go slow iterating over each element)
+rnd <- aqp::combine(lapply(1:n, random_profile, SPC = TRUE))
+
+# create set of n pairs of random top and bottom depths
 rnd_dep <- data.frame(top = round(runif(n, 10, 20)),
- bottom = round(runif(n, 30, 40)))
+                      bottom = round(runif(n, 30, 40)))
 
-system.time(aqp::combine(lapply(
-  1:nrow(rnd_dep), \(i) {
-    glom(rnd[i, ], rnd_dep$top[i], rnd_dep$bottom[i])
-  }
-)))
+# n=1000 pedons benchmark; NEW ~300x faster
+bench::mark(OLD = { aqp::combine(lapply(1:nrow(rnd_dep), function(i) {
+                    glom(rnd[i, ], rnd_dep$top[i], rnd_dep$bottom[i])
+                  }))$top 
+                  }, 
+            NEW = { 
+                    glom(rnd[1:n, ], rnd_dep$top, rnd_dep$bottom)$top 
+                  }, iterations = 10)
 
-system.time(glom(rnd[1:n, ], rnd_dep$top, rnd_dep$bottom))
+# expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time    
+# <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>         
+#   1 OLD       11.1s    14.2s    0.0737        NA     1.95    10   264      2.26m 
+#   2 NEW      35.4ms   39.7ms   24.2           NA     2.42    10     1   414.05ms
 
+# benchmark with "typical" SPC, loafercreek, n=106; NEW ~25% faster
 data(loafercreek, package='soilDB')
 
-argillic <- profileApply(loafercreek, 
-                         \(x) data.frame(id = profile_id(x),
-                                         t(getArgillicBounds(x))),
+# calculate argillic boundaries using profileApply (iterating over individual profiles)
+argillic <- profileApply(loafercreek, function(x) data.frame(id = profile_id(x), t(getArgillicBounds(x))),
                          frameify = TRUE)
 
-microbenchmark(\(x) 
+# old: glom boundaries iterating over individual profiles, then re-combine into single SPC
+microbenchmark( 
   aqp::combine(lapply(1:nrow(argillic), function(i) 
     glom(loafercreek[i,], argillic$ubound[i], argillic$lbound[i])))
 )
+# min lq   mean median uq  max neval
+# 86 89 174.97     90 92 7299   100
 
-microbenchmark(\(x) 
+# new: process with vectorized glom
+microbenchmark(
   glom(loafercreek, argillic$ubound, argillic$lbound)
 )
+# min lq   mean median uq  max neval
+# 86 89 131.81     90 92 3315   100
+
 
 # multiglom data.table testing
 
+# all "argillic horizons" in loafercreek (via 't' subscript)
 plot(glom(loafercreek, argillic$ubound, argillic$lbound))
 
 p <- loafercreek[3:5,]
@@ -43,27 +61,33 @@ modality <- "all"
 truncate <- TRUE
 as.list <- FALSE
 
-# internal method comparisons
-.multiglom <- aqp:::.multiglom
-.multiglomDT <- aqp:::.multiglomDT
+# # internal method comparisons
+# .multiglom <- aqp:::.multiglom
+# .multiglomDT <- aqp:::.multiglomDT
 
-# both are vectorized over p
-expect_equal(.multiglom(p, z1[1], z2[1]),
-             .multiglomDT(p, z1[1], z2[1]))
-
-# .multiglomDT is vectorized over z1 and z2 as well as p
-expect_equal(c(.multiglom(p[1, ], z1[1], z2[1]),
-               .multiglom(p[2, ], z1[2], z2[2]),
-               .multiglom(p[3, ], z1[3], z2[3])),
-             .multiglomDT(p, z1, z2))
+# # both are vectorized over p
+# expect_equal(.multiglom(p, z1[1], z2[1]),
+#              .multiglomDT(p, z1[1], z2[1]))
+# 
+# # .multiglomDT is vectorized over z1 and z2 as well as p
+# expect_equal(c(.multiglom(p[1, ], z1[1], z2[1]),
+#                .multiglom(p[2, ], z1[2], z2[2]),
+#                .multiglom(p[3, ], z1[3], z2[3])),
+#              .multiglomDT(p, z1, z2))
 
 # alternating z1/z2
 z1 <- c(rep(c(0,55), 5))[1:9]
 z2 <- c(rep(c(10,60), 5))[1:9]
 
+# sp1 dataset
 data(sp1)
 depths(sp1) <- id ~ top + bottom
 
-par(mar=c(1,1,3,1))
-plot(sp1, max.depth=60)
-plot(glom(sp1, z1, z2, truncate=TRUE), max.depth=60, add=T, color="prop", name = NA)
+# profiles colored in with "prop" alternate [0-10] and [55-60]
+par(mar = c(1, 1, 3, 1))
+plot(sp1, max.depth = 60)
+plot(glom(sp1, z1, z2, truncate = TRUE),
+     max.depth = 60,
+     add = TRUE,
+     color = "prop",
+     name = NA)

--- a/tests/testthat/test-genhz.R
+++ b/tests/testthat/test-genhz.R
@@ -29,7 +29,7 @@ test_that("advanced pattern matching, requires perl", {
 
   # the last pattern requires perl-compatible REGEX
   # error without perl=TRUE
-  expect_error(generalize.hz(x, new = n, pat=p, non.matching.code = 'not-used'))
+  expect_error(suppressWarnings(generalize.hz(x, new = n, pat=p, non.matching.code = 'not-used')))
 
   # this should work
   res <- generalize.hz(x, new = n, pat=p, non.matching.code = 'not-used', perl=TRUE)

--- a/tests/testthat/test-mollic.R
+++ b/tests/testthat/test-mollic.R
@@ -1,22 +1,28 @@
 context("estimate mollic epipedon bounds")
 # construct a fake profile
-spc <- data.frame(id=1, taxsubgrp = "Lithic Haploxeralfs",
-                  hzname   = c("A","AB","Bt","BCt","R"),
-                  hzdept   = c(0,  20, 32, 42,  49),
-                  hzdepb   = c(20, 32, 42, 49, 200),
-                  prop     = c(18, 22, 28, 24,  NA),
-                  texcl    = c("l","l","cl", "l","br"),
-                  d_value  = c(5,   5,  5,  6,  NA),
-                  m_value  = c(2.5, 3,  3,  4,  NA),
-                  m_chroma = c(2,   3,  4,  4,  NA))
+spc <- data.frame(
+  id = 1,
+  taxsubgrp = "Lithic Haploxeralfs",
+  hzname   = c("A", "AB", "Bt", "BCt", "R"),
+  hzdept   = c(0,  20, 32, 42,  49),
+  hzdepb   = c(20, 32, 42, 49, 200),
+  prop     = c(18, 22, 28, 24,  NA),
+  texcl    = c("l", "l", "cl", "l", "br"),
+  d_value  = c(5,   5,  5,  6,  NA),
+  m_value  = c(2.5, 3,  3,  4,  NA),
+  m_chroma = c(2,   3,  4,  4,  NA)
+)
 
-spc2 <- structure(list(id = c(1,1,1,1), hzname = c("A", "Bt1", "Bt2", "Bk"), 
-                       hzdept = c(0L, 5L, 16L, 36L), 
-                       hzdepb = c(5L, 16L, 36L, 66L), 
-                       claytotest = c(11L, 30L, 32L, 11L), 
-                       texcl = c("sl", "scl", "scl", "sl"), 
-                       d_value = c(6L, 4L, 4L, 4L, 4L), m_chroma = c(2L, 2L,  3L, 3L)), 
-                  class = "data.frame", row.names = c(NA, -4L))
+spc2 <- data.frame(
+  id = c(1, 1, 1, 1),
+  hzname = c("A", "Bt1", "Bt2", "Bk"),
+  hzdept = c(0L, 5L, 16L, 36L),
+  hzdepb = c(5L, 16L, 36L, 66L),
+  claytotest = c(11L, 30L, 32L, 11L),
+  texcl = c("sl", "scl", "scl", "sl"),
+  d_value = c(6L, 4L, 4L, 4L),
+  m_chroma = c(2L, 2L,  3L, 3L)
+)
 
 # promote to SoilProfileCollection
 depths(spc) <- id ~ hzdept + hzdepb
@@ -30,7 +36,7 @@ hztexclname(spc2) <- 'texcl'
 
 test_that("mollic.thickness.requirement", {
   expect_equal(mollic.thickness.requirement(spc, clay.attr = 'prop'), 18)
-  expect_equal(mollic.thickness.requirement(spc,  clay.attr = 'prop', truncate = FALSE), 49 / 3)
+  expect_equal(mollic.thickness.requirement(spc, clay.attr = 'prop', truncate = FALSE), 49 / 3)
   expect_equal(mollic.thickness.requirement(trunc(spc, 0, 9),  clay.attr = 'prop'), 10)
   
   # this is a controversial/undefined case:

--- a/tests/testthat/test-soil-depth.R
+++ b/tests/testthat/test-soil-depth.R
@@ -89,7 +89,7 @@ test_that("depth to feature using REGEX on hzname: [Bt]", {
 
 
 test_that("depthOf - simple match", {
-  expect_equal(depthOf(d[1,], "Cr|R|Cd"), NA)
+  expect_equal(depthOf(d[1,], "Cr|R|Cd"), NA_real_)
   expect_equal(depthOf(d[2,], "Cr|R|Cd"), 55)
   expect_equal(minDepthOf(d[2,], "Cr|R|Cd"), 55)
   expect_equal(maxDepthOf(d[2,], "Cr|R|Cd"), 55)
@@ -106,8 +106,8 @@ test_that("depthOf - multiple match", {
 })
 
 test_that("depthOf - no match", {
-  expect_equal(depthOf(d[1,], "X"), NA)
-  expect_equal(depthOf(d[2,], "Cr|R|Cd", no.contact.depth = 50), NA)
+  expect_equal(depthOf(d[1,], "X"), NA_real_)
+  expect_equal(depthOf(d[2,], "Cr|R|Cd", no.contact.depth = 50), NA_real_)
 
   d2 <- d
   d2$name <- NULL

--- a/tests/testthat/test-surface-thickness.R
+++ b/tests/testthat/test-surface-thickness.R
@@ -21,9 +21,14 @@ test_that("getSurfaceHorizonDepth", {
   expect_equal(t4, 0)
   
   # contiguous and non-contiguous matches below a non-match are ignored (n=1)
-  p$mollic_color <- c("d","l","d","l","d","d")
-  t6 <- getSurfaceHorizonDepth(p, pattern="d", hzdesgn="mollic_color")
+  p$mollic_color <- c("d", "l", "d", "l", "d", "d")
+  t6 <- getSurfaceHorizonDepth(p, pattern = "d", hzdesgn = "mollic_color")
   expect_equal(t6, horizons(p)[1, 'bottom'])
+})
+
+test_that("getSurfaceHorizonDepth in multiple profiles", {
+  expect_equal(as.numeric(profileApply(sp1, getSurfaceHorizonDepth, pattern = "A")),
+               getSurfaceHorizonDepth(sp1, pattern = "A")$bottom)
 })
 
 test_that("getPlowLayerDepth()", {
@@ -43,3 +48,4 @@ test_that("getMineralSoilSurfaceDepth()", {
   rez2 <- getMineralSoilSurfaceDepth(q, hzdesgn='name')
   expect_equivalent(rez2, 5)
 })
+


### PR DESCRIPTION
- Vectorizes `glom()` `z1` and `z2` arguments, so now profile-specific intervals may be specified. `z1` and `z2` must be either length 1 or length equal to number of profiles. `z2` may be `NULL` for "point"-horizon intersection. 
  - `z1` and `z2` now support non-standard evaluation of expressions based on column names in `siteNames(p)`, and also can evaluate character vectors (length 1) that are column names in `siteNames(p)`. This makes new vectorized version even easier to use in pipe-based workflows

- `depthOf` can now be applied to multiple profiles. If length(SPC) > 1 returns a _data.frame_ result containing ID, depth, designation and pattern
  - `minDepthOf` and `maxDepthOf` use a shared functional form, which can also be called via optional `FUN` argument to `depthOf`

- `getSurfaceHorizonDepth()` can now be applied to multiple profiles. If length(SPC) > 1 returns a _data.frame_ result containing ID, depth, designation and pattern
  - `getMineralSoilSurfaceDepth()` and `getPlowLayerDepth()` get the benefits of update to`getSurfaceHorizonDepth()` 

- Uses {data.table} for a big improvement in performance over iterating over single profiles for `glom` and pattern-matching code

- Updated docs