### PR TITLE
Test persistence of attributes and metadata in SoilProfileCollection

### DIFF
--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -1252,6 +1252,26 @@ setMethod(f = 'metadata', signature(object = 'SoilProfileCollection'),
             return(object@metadata)
           })
 
+# takes two SPC as input, takes metadata other than original order from source
+# returns the destination SPC with modified metadata
+.transfer.metadata.aqp <- function(src, dest) {
+  if (inherits(src, 'SoilProfileCollection')) {
+    m <- metadata(src)
+  } else {
+    m <- src
+  }
+  stopifnot(inherits(dest, 'SoilProfileCollection'))
+  
+  # transfer attributes https://github.com/ncss-tech/aqp/issues/204
+  customattr <- attributes(src)
+  customattr <- customattr[!names(customattr) %in% names(attributes(SoilProfileCollection()))]
+  attributes(dest)[names(customattr)] <- attributes(src)[names(customattr)]
+  
+  cols <- names(m)[names(m) != "original.order"]
+  metadata(dest)[cols] <- m[cols]
+  dest
+}
+
 # if (!isGeneric("aqp_df_class"))
   setGeneric("aqp_df_class", function(object)
     standardGeneric("aqp_df_class"))

--- a/R/L1_profiles.R
+++ b/R/L1_profiles.R
@@ -196,6 +196,9 @@ L1_profiles <- function(x, fm, basis = 1, method = c('regex', 'simple', 'constan
   # init SPC with new ID, top, bottom names
   depths(agg) <- group ~ top + bottom
   
+  # transfer metadata
+  agg <- .transfer.metadata.aqp(x, agg)
+  
   return(agg)
 }
 

--- a/R/SoilProfileCollection-operators.R
+++ b/R/SoilProfileCollection-operators.R
@@ -288,7 +288,11 @@ setMethod("[", signature(x = "SoilProfileCollection",
                              diagnostic = .as.data.frame.aqp(d, aqp_df_class(x)),
                              restrictions = .as.data.frame.aqp(r, aqp_df_class(x))
                            )
-
+                           
+                           # preserve metadata that may have been customized relative to defaults
+                           #  in prototype or resulting from construction of SPC
+                           res <- .transfer.metadata.aqp(x, res)
+                           
                            # fill in any missing data.frame class or group var
                            o.df.class <- aqp::metadata(x)$aqp_df_class
                            if(length(o.df.class) == 0) {
@@ -302,13 +306,7 @@ setMethod("[", signature(x = "SoilProfileCollection",
 
                            metadata(res)$aqp_df_class <- o.df.class
                            metadata(res)$aqp_group_by <- o.group.by
-
-                           # preserve slots that may have been customized relative to defaults
-                           #  in prototype or resulting from construction of SPC
-                           suppressMessages(hzidname(res) <- hzidname(x))
-                           suppressMessages(hzdesgnname(res) <- hzdesgnname(x))
-                           suppressMessages(hztexclname(res) <- hztexclname(x))
-
+                           
                            # there should be as many records in @site as there are profile IDs
                            pid.res <- profile_id(res)
                            site.res <- site(res)[[idname(res)]]

--- a/R/SoilProfileCollection-slice-methods.R
+++ b/R/SoilProfileCollection-slice-methods.R
@@ -307,7 +307,7 @@ slice.fast <- function(object, fm, top.down=TRUE, just.the.data=FALSE, strict=TR
   hd.slices@restrictions <- object@restrictions
 
   # copy over metadata
-  hd.slices@metadata <- object@metadata
+  hd.slices <- .transfer.metadata.aqp(object, hd.slices)
 
   ## un-set horizon designation and texture class metadata if they aren't in the sliced data
   hn <- horizonNames(hd.slices)

--- a/R/combine.R
+++ b/R/combine.R
@@ -238,8 +238,6 @@ pbindlist <- function(l, new.idname = NULL, verbose = TRUE) {
   new.metadata <- spc.list[[1]]$metadata
 
   # get the data.frame class and grouping variable into new metadata
-  new.metadata$aqp_df_class <- o.df.class
-  new.metadata$aqp_group_by <- o.group.by
 
   # transfer old slots if they are present
   hzdold <- spc.list[[1]]$hzdesgncol
@@ -456,14 +454,16 @@ pbindlist <- function(l, new.idname = NULL, verbose = TRUE) {
   diagnostic_hz(res) <- .as.data.frame.aqp(o.d, o.df.class)
   restrictions(res) <- .as.data.frame.aqp(o.r, o.df.class)
 
-  # append any novel metadata
-  #  note that o.df.class is calculated from all elements, and defaults to data.frame
-  #  this line is to cover metadata like citations etc. that are not part of all SPCs
-  new.names <- !(names(new.metadata) %in% names(res@metadata))
+  # # append any novel metadata
+  # #  note that o.df.class is calculated from all elements, and defaults to data.frame
+  # #  this line is to cover metadata like citations etc. that are not part of all SPCs
+  # new.names <- !(names(new.metadata) %in% names(res@metadata))
+  # 
+  # # explicit slot replacement
+  # res@metadata <- c(res@metadata, new.metadata[new.names])
 
-  # explicit slot replacement
-  res@metadata <- c(res@metadata, new.metadata[new.names])
-
+  res <- .transfer.metadata.aqp(new.metadata, res)
+  
   # attempt using a common ID
   suppressWarnings(hzidname(res) <- new.hzID)
 

--- a/R/harmonize.R
+++ b/R/harmonize.R
@@ -152,7 +152,7 @@ setMethod("harmonize", signature(x = "SoilProfileCollection"),
           profile_id(p.out) <- paste(profile_id(p), x.sets[i], sep = "_")
 
           # add to site table also (useful for filtering downstream)
-          site(p.out)[[grp.name]] <- x.sets[i]
+          p.out[[grp.name]] <- x.sets[i]
 
           # return modified profile
           return(p.out)

--- a/R/perturb.R
+++ b/R/perturb.R
@@ -356,8 +356,7 @@ perturb <- function(p,
   ## reset horizon IDs
   hzID(res) <- as.character(1:nrow(res))
 
-  # preserve original horizon designation
-  hzdesgnname(res) <- hzdesgnname(p)
+  res <- .transfer.metadata.aqp(p, res)
   
   if (custom.ids & length(unique(id)) == length(res))
     profile_id(res) <- id

--- a/R/rebuildSPC.R
+++ b/R/rebuildSPC.R
@@ -64,15 +64,9 @@ rebuildSPC <- function(x) {
     hztexclname(res) <- x.list$hztexclcol
   }
 
-  # metadata is a list now
-  olddata <- as.list(x.list$metadata)
-
-  # depths sets up basic metadata for res, copy over any missing data elements
-  x.list$metadata <- c(metadata(res), olddata[!names(olddata) %in% names(metadata(res))])
-
-  # replace metadata
-  metadata(res) <- x.list$metadata
-
+  # transfer metadata
+  res <- .transfer.metadata.aqp(x, res)
+    
   # replace site
   site(res) <- x.list$site
 

--- a/tests/testthat/test-SoilProfileCollection-metadata.R
+++ b/tests/testthat/test-SoilProfileCollection-metadata.R
@@ -1,0 +1,51 @@
+test_that("metadata and attributes are persistent", {
+
+  data("sp3")
+  
+  depths(sp3) <- id ~ top + bottom
+  
+  depth_units(sp3) <- "fathoms"
+  metadata(sp3)$something_custom <- "all your profiles are belong to us"
+  attr(sp3, 'attribution') <- "the most attributable of all attributes"
+  
+  # thickness standard deviation for perturb()
+  sp3$thickness_attr <- rep(1, nrow(sp3))
+  
+  cols <- c(
+    "aqp_df_class",
+    "aqp_group_by",
+    "aqp_hzdesgn",
+    "aqp_hztexcl",
+    "depth_units",
+    "stringsAsFactors",
+    "something_custom"
+  )
+  
+  .check_metadata_and_attribution <- function(obj, src, check_attr = TRUE) {
+    # check metadata() other than original.order
+    expect_equal(metadata(src)[cols], metadata(obj)[cols])
+    # check attribute persistence via .transfer.attributes.aqp
+    if (check_attr) expect_equal(attr(src, 'attribution'),  attr(obj, 'attribution'))
+  }
+  
+  # compare when subsetting
+  obj <- sp3[1,]
+  .check_metadata_and_attribution(obj, sp3)
+  
+  # compare when combined
+  obj <- combine(sp3[1,], sp3[2,])
+  # NOTE: do not expect attributes to be transferred after combination operation
+  .check_metadata_and_attribution(obj, sp3, check_attr = FALSE)
+  
+  # compare when rebuilt
+  obj <- rebuildSPC(sp3)
+  .check_metadata_and_attribution(obj, sp3)
+  
+  # compare when L1_profile-d
+  obj <- L1_profiles(sp3[1:3, ], id ~ clay + ph + tc + cec, method = "simple")
+  .check_metadata_and_attribution(obj, sp3)
+  
+  # compare when perturbed
+  obj <- perturb(sp3[1,], thickness.attr = "thickness_attr")
+  .check_metadata_and_attribution(obj, sp3)
+})


### PR DESCRIPTION
Closes #204

 - Add test for metadata persistence

 - Fix persistence of metadata using [, combine, rebuildSPC, L1_profiles and perturb

 - Transfer attributes in routine operations that also transfer metadata