### PR TITLE
Add `as.character(<SoilProfileCollection>)`

### DIFF
--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -55,11 +55,6 @@ setClass(
   }
 )
 
-#' @export
-setMethod('as.character', 'SoilProfileCollection', function(x, ...) {
-  paste0('SPC<', length(x), '>')
-})
-
 # 2019-03-15: creating an empty SpatialPoints object requires more effort
 # c/o: https://gis.stackexchange.com/questions/291069/creating-empty-spatialpoints-or-spatialpointsdataframe-in-r
 # old: new('SpatialPoints')
@@ -420,7 +415,15 @@ setMethod(f = 'show',
 
           })
 
-
+#' @description `as.character()`: Character Representation of SoilProfileCollection Object
+#' @param x a SoilProfileCollection
+#' @param ... additional arguments (not used)
+#' @keywords internal
+#' @rdname show
+#' @export
+setMethod('as.character', 'SoilProfileCollection', function(x, ...) {
+  paste0('SPC<', length(x), '>')
+})
 
 #' @title Wrapper method for data.frame subclass conversion
 #'

--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -422,7 +422,7 @@ setMethod(f = 'show',
 #' @rdname show
 #' @export
 setMethod('as.character', 'SoilProfileCollection', function(x, ...) {
-  paste0('SPC<', length(x), '>')
+  paste0('SPC<', length(x), ",", nrow(x), '>')
 })
 
 #' @title Wrapper method for data.frame subclass conversion

--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -55,6 +55,11 @@ setClass(
   }
 )
 
+#' @export
+setMethod('as.character', 'SoilProfileCollection', function(x, ...) {
+  paste0('SPC<', length(x), '>')
+})
+
 # 2019-03-15: creating an empty SpatialPoints object requires more effort
 # c/o: https://gis.stackexchange.com/questions/291069/creating-empty-spatialpoints-or-spatialpointsdataframe-in-r
 # old: new('SpatialPoints')

--- a/man/show.Rd
+++ b/man/show.Rd
@@ -4,17 +4,26 @@
 \name{show}
 \alias{show}
 \alias{show,SoilProfileCollection-method}
+\alias{as.character,SoilProfileCollection-method}
 \title{SoilProfileCollection show method}
 \usage{
 \S4method{show}{SoilProfileCollection}(object)
+
+\S4method{as.character}{SoilProfileCollection}(x, ...)
 }
 \arguments{
 \item{object}{a SoilProfileCollection}
+
+\item{x}{a SoilProfileCollection}
+
+\item{...}{additional arguments (not used)}
 }
 \description{
 Pretty output method for SoilProfileCollection objects. By default this method limits output to 10 columns and 6 rows from the site and horizon tables respectively.
 
 There is an aqp environment option you can set to increase the number of columns shown by default: \code{options(.aqp.show.n.cols = 100)},
+
+\code{as.character()}: Character Representation of SoilProfileCollection Object
 }
 \examples{
 
@@ -28,3 +37,4 @@ show(sp5)
 sp5
 
 }
+\keyword{internal}


### PR DESCRIPTION
Currently, you can store a list of SoilProfileCollection as a column of a data.frame when protected with `I()`. This could be pretty convenient if you have multiple groups of pedons that you need to manage.

But if you try to print that data frame in the console, you will get an error because there is no way to represent the list of SPC as a character vector. 

If we were to define the S4 method `as.character()` for the SoilProfileCollection this would be resolved. 
This PR provides an example of how it could be defined; formatting could be changed as needed.

``` r
library(aqp, warn.conflicts = FALSE)
#> This is aqp 1.31

data(sp1)
depths(sp1) <- id ~ top + bottom

data(sp2)
depths(sp2) <- id ~ top + bottom

test <- data.frame(id = 1:2, foo = I(list(sp1, sp2)))
test
#> Error in as.character.default(new("SoilProfileCollection", idcol = "id", : no method for coercing this S4 class to a vector

# define as.character(<SPC>)
setMethod('as.character', 'SoilProfileCollection', function(x, ...) {
  paste0('SPC<', length(x), '>')
})

# inspect after defining the as.character method
test
#>   id     foo
#> 1  1  SPC<9>
#> 2  2 SPC<18>

# use the list column
lapply(test$foo, function(x) profileApply(x, aqp::estimateSoilDepth))
#> [[1]]
#> P001 P002 P003 P004 P005 P006 P007 P008 P009 
#>   89   59   67   62   68  200  233  200  240 
#> 
#> [[2]]
#>  hon-1 hon-10 hon-11 hon-13 hon-14 hon-17 hon-18 hon-19  hon-2 hon-20 hon-21 
#>    170    225    220    301    320    295    300    410    130    283   1300 
#> hon-22  hon-3  hon-4  hon-5  hon-6  hon-7  hon-8 
#>   1300     78    147    180    184    370    390
```

