### PR TITLE
Empty SPC prototype should be able to preserve horizon names

### DIFF
--- a/R/SoilProfileCollection-methods.R
+++ b/R/SoilProfileCollection-methods.R
@@ -75,9 +75,10 @@ setMethod(
     x@horizons <- h[idx,]
     
     # return the shallowest (of the deepest depths in each profile)
+    # returning Inf with no non-missing arguments to min
     .LAST <- NULL
     .HZID <- NULL
-    return(min(horizons(x)[x[,, .LAST, .HZID],][[htb[2]]], na.rm = na.rm))
+    return(suppressWarnings(min(horizons(x)[x[,, .LAST, .HZID],][[htb[2]]], na.rm = na.rm)))
   }
 )
 
@@ -114,9 +115,10 @@ setMethod(
     
     
     # return the deepest (of the deepest depths in each profile)
+    # returning -Inf with no non-missing arguments to max
     .LAST <- NULL
     .HZID <- NULL
-    return(max(horizons(x)[x[,, .LAST, .HZID],][[htb[2]]], na.rm = na.rm))
+    return(suppressWarnings(max(horizons(x)[x[,, .LAST, .HZID],][[htb[2]]], na.rm = na.rm)))
   }
 )
 

--- a/R/SoilProfileCollection-setters.R
+++ b/R/SoilProfileCollection-setters.R
@@ -87,19 +87,29 @@ setReplaceMethod("depths", "data.frame",
   return(depth)
 }
 
-.prototypeSPC <- function(idn, hzd) {
+# create 0-length spc from id and horizon depth columns (`idn`, `hzd`)
+#  - allows template horizon (`hz`) and site (`st`) data to be provided (for additional columns)
+.prototypeSPC <- function(idn, hzd, hz = data.frame(), st = data.frame()) {
   
+  # create bare minimum data
   nuhz <- data.frame(id = character(0), 
                      hzID = character(0), 
                      top = numeric(0),
                      bottom = numeric(0), 
                      stringsAsFactors = FALSE)
+  # use idname/horizon depths
   colnames(nuhz) <- c(idn, "hzID", hzd)
   
+  # dummy site data
   nust <- data.frame(id = character(0), 
                      stringsAsFactors = FALSE)
   colnames(nust) <- idn
   
+  # add other columns
+  nuhz <- cbind(nuhz, hz[0, !colnames(hz) %in% colnames(nuhz), drop = FALSE])
+  nust <- cbind(nuhz, st[0, !colnames(st) %in% colnames(nust), drop = FALSE])
+  
+  # return 0-length SPC
   return(SoilProfileCollection(idcol = idn, 
                                depthcols = hzd,
                                horizons = nuhz,
@@ -139,7 +149,7 @@ setReplaceMethod("depths", "data.frame",
   if (all(is.na(data[[depthcols[1]]])) || all(is.na(data[[depthcols[2]]]))) {
       warning("all top and/or bottom depths missing from input data", call. = FALSE)
       # return a empty (0-length) SPC prototype using id and depthcols
-      return(.prototypeSPC(nm[1], depthcols))
+      return(.prototypeSPC(nm[1], depthcols, hz = data))
   }
 
   tdep <- data[[depthcols[1]]]

--- a/R/SoilProfileCollection-setters.R
+++ b/R/SoilProfileCollection-setters.R
@@ -19,8 +19,8 @@ setReplaceMethod("depths", signature(object = "SoilProfileCollection"),
 #' @name depths<-
 #' @param object An object to promote to SoilProfileCollection (inherits from data.frame)
 #' @param value A formula specifying the unique profile ID, top and bottom depth column names
-#'
 #' @aliases depths<-,data.frame-method
+#' @details The input horizon data, and the resulting profile order, is sorted based on unique profile ID and top depth. ID columns are converted to character, depth columns are converted to integer. If `NA` values exist in all of the top depths, a prototype with 1 horizon per profile ID is returned, with `NA` in all non-essential columns. If the input `object` has 0 rows, a prototype with 0 horizons and 0 rows, but same column names as `object`, is returned. 
 #' @rdname depths
 #'
 #' @examples
@@ -89,27 +89,32 @@ setReplaceMethod("depths", "data.frame",
 
 # create 0-length spc from id and horizon depth columns (`idn`, `hzd`)
 #  - allows template horizon (`hz`) and site (`st`) data to be provided (for additional columns)
-.prototypeSPC <- function(idn, hzd, hz = data.frame(), st = data.frame()) {
+.prototypeSPC <- function(idn, hzd, 
+                          hz = data.frame(), st = data.frame(), 
+                          fill_top = NA_integer_, fill_bottom = NA_integer_) {
   
   # create bare minimum data
-  nuhz <- data.frame(id = character(0), 
-                     hzID = character(0), 
-                     top = numeric(0),
-                     bottom = numeric(0), 
+  id <- hz[[idn]]
+  nid <- length(id)
+  iid <- seq_along(id)
+  nuhz <- data.frame(id = as.character(id), 
+                     hzID = iid, 
+                     top = fill_top[nid],
+                     bottom = fill_bottom[nid], 
                      stringsAsFactors = FALSE)
   # use idname/horizon depths
   colnames(nuhz) <- c(idn, "hzID", hzd)
   
   # dummy site data
-  nust <- data.frame(id = character(0), 
+  nust <- data.frame(id = as.character(id), 
                      stringsAsFactors = FALSE)
   colnames(nust) <- idn
   
   # add other columns
-  nuhz <- cbind(nuhz, hz[0, !colnames(hz) %in% colnames(nuhz), drop = FALSE])
-  nust <- cbind(nuhz, st[0, !colnames(st) %in% colnames(nust), drop = FALSE])
+  nuhz <- cbind(nuhz, hz[0, !colnames(hz) %in% colnames(nuhz), drop = FALSE][iid,])
+  nust <- cbind(nuhz, st[0, !colnames(st) %in% colnames(nust), drop = FALSE][iid,])
   
-  # return 0-length SPC
+  # return 0-length or n-length (ID only) SPC
   return(SoilProfileCollection(idcol = idn, 
                                depthcols = hzd,
                                horizons = nuhz,
@@ -118,8 +123,12 @@ setReplaceMethod("depths", "data.frame",
 
 ##
 ## initialize SP/SPC objects from a model.frame
-##
-.initSPCfromMF <- function(data, mf, use_class) {
+## - data is a horizon-level data.frame
+## - mf is a model frame expressing the id ~ top + bottom formula
+## - use_class is the data.frame class to use ("data.frame", "tbl_df", or "data.table")
+## 
+# TODO: top and bottom are depth used to fill in an empty horizon for profiles where all top depths are missing. Default `NA_integer_`. Not exposed through depths<- at this time because it only covers the case where every single profile in the collection has all missing top depths. Doing more involved inspection of the SPC inputs to find cases that may have multiple NA-horizons per profile, removing extras, splicing in clean NA-filled data may be more than we want to do in the object constructing method
+.initSPCfromMF <- function(data, mf, use_class, top = NA_integer_, bottom = NA_integer_) {
   # get column names containing id, top, bottom
   nm <- names(mf)
 
@@ -138,20 +147,25 @@ setReplaceMethod("depths", "data.frame",
   # depth column names
   depthcols <- c(nm[2], nm[3])
 
-  # enforce numeric depths and provide QC warnings as needed
-  data[[depthcols[1]]] <- .checkNAdepths(data[[depthcols[1]]], "top")
-  data[[depthcols[2]]] <- .checkNAdepths(data[[depthcols[2]]], "bottom")
-
   # get column containing IDs
   data_id <- data[[nm[1]]]
 
   # check for all depths NA or 0-length
-  if (all(is.na(data[[depthcols[1]]])) || all(is.na(data[[depthcols[2]]]))) {
-      warning("all top and/or bottom depths missing from input data", call. = FALSE)
-      # return a empty (0-length) SPC prototype using id and depthcols
-      return(.prototypeSPC(nm[1], depthcols, hz = data))
+  if (all(is.na(data[[depthcols[1]]]))) {
+    # all top depths missing is intractable, all bottom depths is fixable
+    warning("all top depths missing from input data", call. = FALSE)
+    # return a filled (n-length) SPC prototype from the horizon data
+    return(.prototypeSPC(nm[1], depthcols, hz = data, fill_top = top, fill_bottom = bottom))
+  } else if(nrow(data) == 0) {
+    warning("input data have 0 rows", call. = FALSE)
+    # return a empty (0-length) SPC prototype from the horizon data
+    return(.prototypeSPC(nm[1], depthcols, hz = data, fill_top = top, fill_bottom = bottom))
   }
-
+  
+  # enforce numeric depths and provide QC warnings as needed
+  data[[depthcols[1]]] <- .checkNAdepths(data[[depthcols[1]]], "top")
+  data[[depthcols[2]]] <- .checkNAdepths(data[[depthcols[2]]], "bottom")
+  
   tdep <- data[[depthcols[1]]]
 
   # calculate ID-top depth order, re-order input data
@@ -170,6 +184,7 @@ setReplaceMethod("depths", "data.frame",
                                site = nusite,
                                horizons = data)
 
+  
   # check for horizon ID name conflict
   if (hzidname(res) %in% names(data)) {
 

--- a/R/SoilProfileCollection-setters.R
+++ b/R/SoilProfileCollection-setters.R
@@ -111,9 +111,18 @@ setReplaceMethod("depths", "data.frame",
   colnames(nust) <- idn
   
   # add other columns
-  nuhz <- cbind(nuhz, hz[0, !colnames(hz) %in% colnames(nuhz), drop = FALSE][iid,])
-  nust <- cbind(nuhz, st[0, !colnames(st) %in% colnames(nust), drop = FALSE][iid,])
+  if (ncol(hz) > 0) {
+    hz$.dummyVar <- ""[nrow(hz)]
+    nuhz <- cbind(nuhz, hz[0, !colnames(hz) %in% colnames(nuhz), drop = FALSE][iid,])
+    nuhz$.dummyVar <- NULL
+  }
   
+  if (ncol(st) > 0) {
+    st$.dummyVar <- ""[nrow(st)]
+    nust <- cbind(nust, st[0, !colnames(st) %in% colnames(nust), drop = FALSE][iid,])
+    nust$.dummyVar <- NULL
+  }
+    
   # return 0-length or n-length (ID only) SPC
   return(SoilProfileCollection(idcol = idn, 
                                depthcols = hzd,

--- a/man/depths.Rd
+++ b/man/depths.Rd
@@ -18,6 +18,9 @@
 \description{
 Initialize a SoilProfileCollection from a data.frame object
 }
+\details{
+The input horizon data, and the resulting profile order, is sorted based on unique profile ID and top depth. ID columns are converted to character, depth columns are converted to integer. If \code{NA} values exist in all of the top depths, a prototype with 1 horizon per profile ID is returned, with \code{NA} in all non-essential columns. If the input \code{object} has 0 rows, a prototype with 0 horizons and 0 rows, but same column names as \code{object}, is returned.
+}
 \examples{
 ## init SoilProfileCollection objects from data.frame of horizon data
 

--- a/tests/testthat/test-SoilProfileCollection-setters.R
+++ b/tests/testthat/test-SoilProfileCollection-setters.R
@@ -1,0 +1,27 @@
+test_that(".prototypeSPC works", {
+  # basic functionality: create a 0 length SPC with specified id ~ top + bottom
+  x <- .prototypeSPC("id", c("top", "bottom"))
+  expect_true(inherits(x, 'SoilProfileCollection'))
+  expect_equal(length(x), 0)
+  expect_equal(names(x), c(horizons1 = "id", horizons2 = "hzID", 
+                           horizons3 = "top", horizons4 = "bottom"))
+  
+  # one additional horizon column works (degenerate case)
+  x1 <- .prototypeSPC("id", c("top", "bottom"), 
+                      hz = data.frame(id = 1, top = NA, bottom = NA, foo = "bar")[0,])
+  x2 <- .prototypeSPC("id", c("top", "bottom"),  
+                      hz = data.frame(id = 1:10, top = NA, bottom = NA, foo = "bar"))
+  expect_equal(length(x1), 0) # zero length in, zero length out
+  expect_true(length(x2) == 10 && nrow(x2) == 10) # all NA depths -> 1 NA row / profile
+  expect_true("foo" %in% horizonNames(x1) && "foo" %in% horizonNames(x2))
+  
+  # two or more additional column (site and horizon) with depth filling works
+  x3 <- .prototypeSPC("id", c("top", "bottom"), 
+                      hz = data.frame(id = 1, top = NA, bottom = NA, foo = "bar", baz = "qux"),
+                      st = data.frame(id = 1, sitevar = "eroded"),
+                      fill_top = 0, fill_bottom = 200)
+  expect_equal(length(x3), 1)
+  expect_true(all(c("foo", "baz") %in% horizonNames(x3)))
+  expect_true(all(c("id", "sitevar") %in% siteNames(x3)))
+  expect_true(x3$top == 0 & x3$bottom == 200)
+})


### PR DESCRIPTION
This is an extension of a prior update involving 0-length SPCs and horizon data where all depths are NA: https://github.com/ncss-tech/aqp/pull/218. This is possibly related to #214 

This PR is to allow for column names from a source (possibly empty) site or horizon data.frame to be included in the "prototype" SPC created by `.prototypeSPC()`. Previously only the required column names were filled in, allowing for idname/depthcols customization and returning a valid 0-length SPC, but dropping other columns that may have been present in the horizon data being promoted to SPC.

My main interest is to ensure that after construction a prototype SPC has the same names as another SPC that was created from more complete horizon data.

# before

``` r
library(aqp)
#> This is aqp 1.33
x <- data.frame(id = c(1,1,1,2,2), top = c(0,10,20,0,50), bottom=c(10,20,50,50,100), foo="asdf")
x2 <- x[0,]
depths(x) <- id ~ top + bottom
x
#> SoilProfileCollection with 2 profiles and 5 horizons
#> profile ID: id  |  horizon ID: hzID 
#> Depth range: 50 - 100 cm
#> 
#> ----- Horizons (5 / 5 rows  |  5 / 5 columns) -----
#>  id hzID top bottom  foo
#>   1    1   0     10 asdf
#>   1    2  10     20 asdf
#>   1    3  20     50 asdf
#>   2    4   0     50 asdf
#>   2    5  50    100 asdf
#> 
#> ----- Sites (2 / 2 rows  |  1 / 1 columns) -----
#>  id
#>   1
#>   2
#> 
#> Spatial Data:
#> [EMPTY]
"foo" %in% names(x)
#> [1] TRUE

depths(x2) <- id ~ top + bottom
#> Warning: all top and/or bottom depths missing from input data
"foo" %in% names(x2)
#> [1] FALSE
```

# after
``` r

library(aqp)
#> This is aqp 1.33
x <- data.frame(id = c(1,1,1,2,2), top = c(0,10,20,0,50), bottom=c(10,20,50,50,100), foo="asdf")
x2 <- x[0,]
depths(x) <- id ~ top + bottom
x
#> SoilProfileCollection with 2 profiles and 5 horizons
#> profile ID: id  |  horizon ID: hzID 
#> Depth range: 50 - 100 cm
#> 
#> ----- Horizons (5 / 5 rows  |  5 / 5 columns) -----
#>  id hzID top bottom  foo
#>   1    1   0     10 asdf
#>   1    2  10     20 asdf
#>   1    3  20     50 asdf
#>   2    4   0     50 asdf
#>   2    5  50    100 asdf
#> 
#> ----- Sites (2 / 2 rows  |  1 / 1 columns) -----
#>  id
#>   1
#>   2
#> 
#> Spatial Data:
#> [EMPTY]
"foo" %in% names(x)
#> [1] TRUE

depths(x2) <- id ~ top + bottom
#> Warning: all top and/or bottom depths missing from input data
"foo" %in% names(x2)
#> [1] TRUE

x2
#> SoilProfileCollection with 0 profiles and 0 horizons
#> profile ID: id  |  horizon ID: hzID 
#> Depth range: NA - NA cm
#> 
#> ----- Horizons (0 / 0 rows  |  5 / 5 columns) -----
#> [1] id     hzID   top    bottom foo   
#> <0 rows> (or 0-length row.names)
#> 
#> ----- Sites (0 / 0 rows  |  1 / 1 columns) -----
#> [1] id
#> <0 rows> (or 0-length row.names)
#> 
#> Spatial Data:
#> [EMPTY]
```

---

Thinking on the handling of 0-length SPCs and input horizon data where either no rows or no rows with non-NA depths. I am wondering if there should be some way to create an `NA`/safe missing data horizon-filled SPC that can preserve site ID; primarily so related site info can be joined in after SPC construction. 

 - Returning a 0-length SPC makes sense when the input data.frame has column names but 0-rows. The behavior when an input horizon data.frame has only site ID level information and the rest including depths as NA is an important case. Getting a 0-length result is a bit more unexpected when the input data.frame had several "horizons" with depths NA. I am reflecting on the fact that if all top or bottom depths are NA we drop all horizons (and thus drop the site too)
 
 - The way we "fill" SPCs in fetchNASIS() (e.g. https://github.com/ncss-tech/soilDB/issues/131; https://github.com/ncss-tech/soilDB/pull/199) is adding one horizon per profile where top and bottom depth are NA. This can be for example product of a LEFT JOIN of chorizon to component where the component is a miscellaneous area or minor component without horizons. 
