### PR TITLE
repairMissingHzDepths: Use `spc_horizonOffset()`

### DIFF
--- a/R/repairMissingHzDepths.R
+++ b/R/repairMissingHzDepths.R
@@ -1,23 +1,71 @@
 #' @title Repair Problematic Lower Horizon Depths
 #' 
-#' @description Attempt a simple repair of horizon bottom depths in the presence of `NA`, or in cases where the horizon shares a common top and bottom depth. Both situations are common in pedon description where "contact" (Cd, Cr, R, etc.) was described without a lower depth. This repair is only applied to the deepest horizon within a profile as identified by [`getLastHorizonID`].
+#' @description Attempt a simple repair of horizon bottom depths in the presence of `NA`, or in cases where the horizon shares a common top and bottom depth. Both situations are common in pedon description where "contact" (Cd, Cr, R, etc.) was described without a lower depth. 
+#' 
+#' @details This repair is applied to the deepest horizon within a profile as identified by [`getLastHorizonID`], as well as to bottom depths of any horizon that has a horizon below it. Horizon bottom depths are adjusted by adding `adj` (if non-NA). If the resulting value exceeds `max.depth`, the `max.depth` value is returned (if not `NA`).
 #' 
 #' @param x `SoilProfileCollection`
 #' 
-#' @param adj vertical offset applied to "repair" affected bottom depths
+#' @param adj vertical offset applied to "repair" missing bottom depths when top and bottom depth are equal or bottom depth is missing. (`NA` to use `max.depth`)
+#' 
+#' @param max.depth If adj is `NA`, or the resulting offset sum exceeds `max.depth`, `max.depth` is used. 
 #' 
 #' @return `SoilProfileCollection` with a new (logical) horizon-level attribute `.repaired` marking affected horizons
+#' @examples 
+#' h <- data.frame(
+#'   id = c(1, 1, 1, 2, 2, 2, 2, 3, 3),
+#'   top = c(0:2, 0:3, 0:1) * 10,
+#'   bottom = c(rep(NA_integer_, 7), c(10, 99))
+#' )
 #' 
-repairMissingHzDepths <- function(x, adj = 10) {
+#' # NA depths result in warnings
+#' suppressWarnings({
+#'   depths(h) <- id ~ top + bottom
+#' })
+#' 
+#' # inspect data before repairs
+#' plot(h)
+#' 
+#' g <- repairMissingHzDepths(h)
+#' 
+#' # all depth logic now valid
+#' all(checkHzDepthLogic(g)$valid)
+#' 
+#' # inspect 
+#' plot(g)
+#' 
+#' # no adj, max.depth only
+#' f <- repairMissingHzDepths(h, adj = NA, max.depth = 200)
+#' all(checkHzDepthLogic(f)$valid)
+#' plot(f) 
+#' 
+#' # max.depth defaults to max(x) if too small
+#' f$bottom[c(3,7)] <- NA
+#' d <- repairMissingHzDepths(f, adj = NA, max.depth = 20)
+#' all(checkHzDepthLogic(d)$valid)
+#' plot(d)
+repairMissingHzDepths <- function(x, adj = 10, max.depth = 200) {
+  # define SPC k-keywords as local vars for R CMD CHECK
+  .LAST <- NULL; .HZID <- NULL
   
   # sanity checks
   if(!inherits(x, 'SoilProfileCollection')) {
     stop('`x` should be a SoilProfileCollection', call. = FALSE)
   }
   
-  # reasonable adj values
-  if(adj < 1) {
-    stop('`adj` should be >= 1', call. = FALSE)
+  if (!is.na(adj)) {
+    # adj must be an integer
+    adj <- round(adj)
+    
+    # reasonable adj values
+    if(adj < 1) {
+      stop('`adj` should be >= 1', call. = FALSE)
+    }
+  }
+  
+  if (!is.na(max.depth) && max.depth < max(x)) {
+    max.depth <- max(x)
+    message("Using max.depth = ", max.depth)
   }
   
   # hz top, bottom, ID names
@@ -25,34 +73,40 @@ repairMissingHzDepths <- function(x, adj = 10) {
   hzidn <- hzidname(x)
   
   # Setup: get horizon IDs of bottom-most horizons of all profiles
-  valid.hzIDs <- getLastHorizonID(x)
+  bottom.idx <- x[,, .LAST, .HZID] # which(hzID(h) %in% getLastHorizonID(h))
+  valid.hzIDs <- hzID(x)[bottom.idx] # getLastHorizonID(x)
   
+  # find NA bottom depths
+  na.bottom <- which(is.na(x[[hztb[2]]]))
   
-  # Step 1: 
-  # find non-NA top AND NA bottom AND (only deepest horizon of each profile)
-  idx1 <- which(
-    !is.na(x[[hztb[1]]]) & is.na(x[[hztb[2]]]) & (x[[hzidn]] %in% valid.hzIDs)
-  )
+  # # Step 1: 
+  # # find non-NA top AND NA bottom AND (only deepest horizon of each profile)
+  # fill in the deepest horizon in each profile if it is missing
+  idx1 <- intersect(na.bottom, as.numeric(bottom.idx))
   
-  # make the edit 
-  x[[hztb[2]]][idx1] <- x[[hztb[1]]][idx1] + adj
-  
+  # # make the edit 
+  x[[hztb[2]]][idx1] <- pmin(x[[hztb[1]]][idx1] + adj, max.depth, na.rm = TRUE)
   
   # Step 2: 
+  # calculate the top depths of the underlying horizon for remaining NA bottom depths
+  idx2 <- setdiff(na.bottom, bottom.idx)
+  
+  # replace the bottom depths
+  x[[hztb[2]]][is.na(x[[hztb[2]]])] <-  x[[hztb[1]]][spc_horizonOffset(x, hzid = idx2, offset = 1)]
+  #                                     x[[hztb[1]]][which(is.na(x[[hztb[2]]])) + 1]
+  
+  
+  # Step 3:
   # top == bottom AND (only deepest horizon of each profile)
-  idx2 <- which(
-    ( x[[hztb[1]]] == x[[hztb[2]]] ) & (x[[hzidn]] %in% valid.hzIDs)
-  )
+  idx3 <- which((x[[hztb[1]]] == x[[hztb[2]]]) & (x[[hzidn]] %in% valid.hzIDs))
   
   # make the edit
-  x[[hztb[2]]][idx2] <- x[[hztb[2]]][idx2] + adj
-  
+  x[[hztb[2]]][idx3] <- pmin(x[[hztb[2]]][idx3] + adj, max.depth, na.rm = TRUE)
   
   # keep track of "repaired" horizons
-  idx <- unique(c(idx1, idx2))
+  idx <- unique(c(idx1, idx2, idx3))
   horizons(x)$.repaired <- FALSE
   horizons(x)$.repaired[idx] <- TRUE
-  
   
   # repaired SPC
   return(x)

--- a/man/repairMissingHzDepths.Rd
+++ b/man/repairMissingHzDepths.Rd
@@ -4,16 +4,55 @@
 \alias{repairMissingHzDepths}
 \title{Repair Problematic Lower Horizon Depths}
 \usage{
-repairMissingHzDepths(x, adj = 10)
+repairMissingHzDepths(x, adj = 10, max.depth = 200)
 }
 \arguments{
 \item{x}{\code{SoilProfileCollection}}
 
-\item{adj}{vertical offset applied to "repair" affected bottom depths}
+\item{adj}{vertical offset applied to "repair" missing bottom depths when top and bottom depth are equal or bottom depth is missing. (\code{NA} to use \code{max.depth})}
+
+\item{max.depth}{If adj is \code{NA}, or the resulting offset sum exceeds \code{max.depth}, \code{max.depth} is used.}
 }
 \value{
 \code{SoilProfileCollection} with a new (logical) horizon-level attribute \code{.repaired} marking affected horizons
 }
 \description{
-Attempt a simple repair of horizon bottom depths in the presence of \code{NA}, or in cases where the horizon shares a common top and bottom depth. Both situations are common in pedon description where "contact" (Cd, Cr, R, etc.) was described without a lower depth. This repair is only applied to the deepest horizon within a profile as identified by \code{\link{getLastHorizonID}}.
+Attempt a simple repair of horizon bottom depths in the presence of \code{NA}, or in cases where the horizon shares a common top and bottom depth. Both situations are common in pedon description where "contact" (Cd, Cr, R, etc.) was described without a lower depth.
+}
+\details{
+This repair is applied to the deepest horizon within a profile as identified by \code{\link{getLastHorizonID}}, as well as to bottom depths of any horizon that has a horizon below it. Horizon bottom depths are adjusted by adding \code{adj} (if non-NA). If the resulting value exceeds \code{max.depth}, the \code{max.depth} value is returned (if not \code{NA}).
+}
+\examples{
+h <- data.frame(
+  id = c(1, 1, 1, 2, 2, 2, 2, 3, 3),
+  top = c(0:2, 0:3, 0:1) * 10,
+  bottom = c(rep(NA_integer_, 7), c(10, 99))
+)
+
+# NA depths result in warnings
+suppressWarnings({
+  depths(h) <- id ~ top + bottom
+})
+
+# inspect data before repairs
+plot(h)
+
+g <- repairMissingHzDepths(h)
+
+# all depth logic now valid
+all(checkHzDepthLogic(g)$valid)
+
+# inspect 
+plot(g)
+
+# no adj, max.depth only
+f <- repairMissingHzDepths(h, adj = NA, max.depth = 200)
+all(checkHzDepthLogic(f)$valid)
+plot(f) 
+
+# max.depth defaults to max(x) if too small
+f$bottom[c(3,7)] <- NA
+d <- repairMissingHzDepths(f, adj = NA, max.depth = 20)
+all(checkHzDepthLogic(d)$valid)
+plot(d)
 }

--- a/tests/testthat/test-repairMissingHzDepths.R
+++ b/tests/testthat/test-repairMissingHzDepths.R
@@ -16,21 +16,54 @@ x$bottom[6] <- x$top[6]
 ## illegal horizons to repair
 x$bottom[12] <- NA
 
-
-
 test_that("works as expected", {
   
   a <- 10
   z <- repairMissingHzDepths(x, adj = a)
   
-  # output is correct
+  # output is an SPC
   expect_true(inherits(z, 'SoilProfileCollection'))
   
-  # legal hz have been repaired according to `a`
+  # bottom depths repaired according to `a` [4,6] or adjacent top depths [12]
   expect_true(z$bottom[4] == z$top[4] + a)
   expect_true(z$bottom[6] == z$top[6] + a)
+  expect_true(z$bottom[12] == sp4$bottom[12])
   
-  # illegal hz have not
-  expect_true(is.na(x$bottom[12]))
+  # repair all missing bottom depths, existing data unaltered
+  h <- data.frame(
+    id = c(1, 1, 1, 2, 2, 2, 2, 3, 3),
+    top = c(0:2, 0:3, 0:1) * 10,
+    bottom = c(rep(NA_integer_, 7), c(10, 99))
+  )
   
+  # NA depths result in warnings
+  expect_warning({
+    depths(h) <- id ~ top + bottom
+  })
+  
+  # all depth logic in resulting SPC is valid, existing data preserved
+  g <- repairMissingHzDepths(h)
+  expect_true(all(checkHzDepthLogic(g)$valid))
+  expect_equal(g[3, ]$bottom[1:2], c(10, 99))
+  expect_equal(min(g), 30)
+  
+  # no adj, max.depth only, existing data preserved
+  f <- repairMissingHzDepths(h, adj = NA, max.depth = 200)
+  expect_true(all(checkHzDepthLogic(f)$valid))
+  expect_equal(f$bottom[c(3, 7, 8, 9)], c(200, 200, 10, 99))
+  expect_equal(min(f), 99)
+  
+  # specifying max.depth too small, existing data preserved
+  f$bottom[c(3,7)] <- NA
+  d <- repairMissingHzDepths(f, max.depth = 20)
+  expect_true(all(checkHzDepthLogic(d)$valid))
+  expect_equal(d$bottom[c(3, 7, 8, 9)], c(30, 40, 10, 99))
+  expect_equal(min(d), 30)
+  
+  # specifying max.depth too small with adj=NA gets an override to max(x), existing data preserved
+  f$bottom[c(3,7)] <- NA
+  d <- repairMissingHzDepths(f, adj = NA, max.depth = 20)
+  expect_true(all(checkHzDepthLogic(d)$valid))
+  expect_equal(d$bottom[c(3, 7, 8, 9)], c(99, 99, 10, 99))
+  expect_equal(min(d), 99)
 })


### PR DESCRIPTION
This PR applies the new function `spc_horizonOffset()`  to extend the repairMissingHzDepths() function