### PR TITLE
`slab()`: pass `formula` argument to aggregate.formula(x, ...)

### DIFF
--- a/R/slab.R
+++ b/R/slab.R
@@ -313,7 +313,7 @@
 
 	# optionally account for extra arguments
 	else {
-		the.args <- c(list(formula=aggregate.fm, data=d.long, na.action=na.pass, FUN=slab.fun), extra.args)
+		the.args <- c(list(aggregate.fm, data=d.long, na.action=na.pass, FUN=slab.fun), extra.args)
 		d.slabbed <- do.call(what='aggregate', args=the.args)
 	}
 


### PR DESCRIPTION
 - adjusts for changes in R 4.2.x; `aggregate.formula()` now follows generic `aggregate(x, ...)` https://bugs.r-project.org/show_bug.cgi?id=18299
 - when passing a (named) list of arguments to `aggregate()` via `do.call()` need to _not_ specify argument name (which is `formula` R < 4.2, and `x` on R >= 4.2)
   - It is implied that `aggregate.formula()` will be called when first argument is class formula