### PR TITLE
Add `.interpretHorizonColor()` outputs to `last_spc_plot` 

### DIFF
--- a/R/plotSPC.R
+++ b/R/plotSPC.R
@@ -510,22 +510,6 @@ plotSPC <- function(
   # re-order y-offset according to plot.order
   y.offset <- y.offset[plot.order]
   
-  # sketch parameters for follow-up overlay / inspection
-  lsp <- list('width' = width,
-              'plot.order' = plot.order,
-              'x0' = relative.pos + x.idx.offset,
-              'pIDs' = pIDs[plot.order],
-              'idname' = idname(x),
-              'y.offset' = y.offset,
-              'scaling.factor' = scaling.factor,
-              'max.depth' = max.depth,
-              'n' = n,
-              'extra_x_space' = extra_x_space,
-              'extra_y_space' = extra_y_space,
-              'hz.depth.LAI' = rep(NA_real_, n)
-  )
-  
-  
   # get horizons
   h <- horizons(x)
   
@@ -562,6 +546,23 @@ plotSPC <- function(
   # legend data if relevant, otherwise NULL
   hz.color.interpretation <- .interpretHorizonColor(h, color, default.color, col.palette, col.palette.bias, n.legend)
   h[['.color']] <- hz.color.interpretation$colors
+  
+  # sketch parameters for follow-up overlay / inspection
+  lsp <- list('width' = width,
+              'plot.order' = plot.order,
+              'x0' = relative.pos + x.idx.offset,
+              'pIDs' = pIDs[plot.order],
+              'idname' = idname(x),
+              'y.offset' = y.offset,
+              'scaling.factor' = scaling.factor,
+              'max.depth' = max.depth,
+              'n' = n,
+              'extra_x_space' = extra_x_space,
+              'extra_y_space' = extra_y_space,
+              'hz.depth.LAI' = rep(NA_real_, n),
+              'legend.colors' = hz.color.interpretation$colors,
+              'legend.data' = hz.color.interpretation$color.legend.data
+  )
   
   
   ####################


### PR DESCRIPTION
Adds `.interpretHorizonColor()` outputs to `last_spc_plot` in `aqp.env` for use in custom `legend()`.

For example:

![image](https://user-images.githubusercontent.com/20842828/168498085-af8ccfc3-abbc-4723-bf45-faf247ffd9d1.png)

<details>

``` r
library(aqp)
#> This is aqp 1.43
library(soilDB)
library(sf)
#> Linking to GEOS 3.10.2, GDAL 3.4.1, PROJ 8.2.1; sf_use_s2() is TRUE
library(sharpshootR)

## copy / paste viewport bounding-box from SoilWeb
## click somewhere on the map
## press 'b', BBOX is copied to the clipboard
bb1 <- '-101.4810 38.0560,-101.4810 38.0620,-101.4675 38.0620,-101.4675 38.0560,-101.4810 38.0560'
bb2 <- '-101.1952 37.8600,-101.1952 37.8843,-101.1410 37.8843,-101.1410 37.8600,-101.1952 37.8600'
x1 <- st_as_sfc(sprintf('POLYGON((%s))', bb1), crs = 4326)
x2 <- st_as_sfc(sprintf('POLYGON((%s))', bb2), crs = 4326)
m1 <- SDA_spatialQuery(x1, what = 'mukey')
m2 <- SDA_spatialQuery(x2, what = 'mukey')

s1 <- get_component_from_SDA(
    sprintf(
      "mukey IN %s AND majcompflag = 'Yes' AND compkind != 'Miscellaneous area'",
      format_SQL_in_statement(as.integer(m1$mukey))
    ), duplicates = TRUE)
#> single result set, returning a data.frame
#> single result set, returning a data.frame
#> single result set, returning a data.frame
#> empty result set

s2 <- get_component_from_SDA(
    sprintf(
      "mukey IN %s AND majcompflag = 'Yes' AND compkind != 'Miscellaneous area'",
      format_SQL_in_statement(as.integer(m2$mukey))
    ), duplicates = TRUE)
#> single result set, returning a data.frame
#> single result set, returning a data.frame
#> single result set, returning a data.frame
#> empty result set

## get OSD morphology
osd1 <- fetchOSD(unique(s1$compname), extended = TRUE)
osd2 <- fetchOSD(unique(s2$compname), extended = TRUE)

## convert horizon boundary distinctness -> vertical distance
osd1$SPC$hzd <- hzDistinctnessCodeToOffset(
  osd1$SPC$distinctness,
  codes = c('very abrupt', 'abrubt', 'clear', 'gradual', 'diffuse')
)
osd2$SPC$hzd <- hzDistinctnessCodeToOffset(
  osd2$SPC$distinctness,
  codes = c('very abrupt', 'abrubt', 'clear', 'gradual', 'diffuse')
)

par(mfrow = c(1, 1))
## arrange sketches according to soil classification
SoilTaxonomyDendrogram(
  combine(osd1$SPC, osd2$SPC),
  color = 'texture_class',
  show.legend = FALSE,
  y.offset = 0.4,
  scaling.factor = 0.0135,
  cex.taxon.labels = 0.75,
  cex.id = 0.66,
  cex.names = 0.66,
  width = 0.25,
  name.style = 'center-center',
  plot.depth.axis = TRUE,
  axis.line.offset = -3,
  hz.distinctness.offset = 'hzd'
)
foo <- get('last_spc_plot', aqp.env)
legend(
  'bottomleft',
  legend = foo$legend.data$legend,
  ncol = 4,
  pch = 15,
  col = foo$legend.data$col,
  bty = "n"
)
```

</details>
