### PR TITLE
Updates to `dice()`, `slab()`, `genSlabLabels()`

### DIFF
--- a/R/dice.R
+++ b/R/dice.R
@@ -27,6 +27,8 @@
 #' 
 #' @param byhz Evaluate horizon depth logic at the horizon level (`TRUE`) or profile level (`FALSE`). Invalid depth logic invokes `HzDepthLogicSubset` which removes offending profiles or horizon records.
 #' 
+#' @param verbose Print information about object size/memory usage. Default: `FALSE`
+#' 
 #' @details For large and potentially messy collections that include missing horizon bottom depths, or 0-thickness horions, consider using `repairMissingHzDepths()` before `dice()`.
 #' 
 #'

--- a/R/genSlabLabels.R
+++ b/R/genSlabLabels.R
@@ -1,54 +1,54 @@
 ## TODO: documentation / generalization
-# note source data must be normalixed via slice() first, e.g. all share the same number of horizons
+# note source data must be "normalized" via dice() first; assumes each profile has the same number of horizons
 
 # generate labels for slabs
-genSlabLabels <- function(slab.structure=1, max.d, n.profiles) {
+genSlabLabels <- function(slab.structure = 1, max.d, n.profiles) {
   
   # fixed-size slabs
-  if(length(slab.structure) == 1) {
+  if (length(slab.structure) == 1) {
     # generate sequence of segment labels
-    seg.label <- rep(1:ceiling(max.d / slab.structure), each=slab.structure, length=max.d)
+    seg.label <- rep(1:ceiling(max.d / slab.structure), each = slab.structure, length = max.d)
+    
     # general segment labels
-    seg.label.levels <- tapply(1:max.d, seg.label, function(i) {r <- range(i); paste(c(r[1]-1, r[2]), collapse='-') } )
+    seg.label.levels <- tapply(1:max.d, seg.label, 
+                               function(i) {
+                                 r <- range(i, na.rm = TRUE)
+                                 paste(c(r[1] - 1, r[2]), collapse = '-')
+                               })
   }
   
   # user-defined slabs
-  if(length(slab.structure) > 1) {
-    # trival case where segments start from 0
-    if(slab.structure[1] == 0 & length(slab.structure) > 2)
-      seg.label <- rep(slab.structure[-1], times=diff(slab.structure))[1:max.d]
+  if (length(slab.structure) > 1) {
+    if (slab.structure[1] == 0 & length(slab.structure) > 2) {
+      # trivial case where segments start from 0
+      
+      
+      seg.label <- rep(slab.structure[-1], times = diff(slab.structure))[1:max.d]
     
-    # other case: user defines an arbitrary lower and upper limit
-    else {
-      if(length(slab.structure) != 2)
+    } else {
+      # other case: user defines an arbitrary lower and upper limit
+      if (length(slab.structure) != 2)
         stop('user-defined slab boundaries must either start from 0, or contain two values between 0 and the max soil depth')
       
-      # proceed
+      # calculate thickness of each slab
       slab.thickness <- diff(slab.structure)
-      # how many slices of NA before the slab?
-      padding.before <- rep(NA, times=slab.structure[1])
-      # how many slices of NA afer the slab
-      padding.after <- rep(NA, times=abs(max.d - slab.structure[2]))
+      
       # make a new label for the slab
-      new.label <- paste(slab.structure, collapse='-')
+      new.label <- paste(slab.structure, collapse = '-')
+      
       # generate an index for the slab
-      slab.idx <- rep(new.label, times=slab.thickness)
-      # generate the entire index: padding+slab+padding = total number of slices (max_d)
-      # seg.label <- c(padding.before, slab.idx, padding.after)
+      slab.idx <- rep(new.label, times = slab.thickness)
       seg.label <- slab.idx 
     }
     
     # generate segment labels	
-    seg.label.levels <- sapply(1:(length(slab.structure)-1), function(i) paste(c(slab.structure[i], slab.structure[i+1]), collapse='-'))
+    seg.label.levels <- sapply(1:(length(slab.structure) - 1), function(i) {
+      paste(c(slab.structure[i], slab.structure[i + 1]), collapse = '-')
+    })
   }
   
   # covert into a factor that can be used to split profiles into slabs
-  res <- factor(rep(seg.label, times=n.profiles), labels=seg.label.levels)
+  res <- factor(rep(seg.label, times = n.profiles), labels = seg.label.levels)
   
   return(res)
 }
-
-
-
-
-

--- a/R/genSlabLabels.R
+++ b/R/genSlabLabels.R
@@ -22,7 +22,6 @@ genSlabLabels <- function(slab.structure = 1, max.d, n.profiles) {
     if (slab.structure[1] == 0 & length(slab.structure) > 2) {
       # trivial case where segments start from 0
       
-      
       seg.label <- rep(slab.structure[-1], times = diff(slab.structure))[1:max.d]
     
     } else {
@@ -30,15 +29,14 @@ genSlabLabels <- function(slab.structure = 1, max.d, n.profiles) {
       if (length(slab.structure) != 2)
         stop('user-defined slab boundaries must either start from 0, or contain two values between 0 and the max soil depth')
       
-      # calculate thickness of each slab
+      # calculate thickness of slab
       slab.thickness <- diff(slab.structure)
       
       # make a new label for the slab
       new.label <- paste(slab.structure, collapse = '-')
       
-      # generate an index for the slab
       slab.idx <- rep(new.label, times = slab.thickness)
-      seg.label <- slab.idx 
+      seg.label <- slab.idx
     }
     
     # generate segment labels	

--- a/R/slab.R
+++ b/R/slab.R
@@ -1,7 +1,7 @@
 # default slab function for categorical variables
 # returns a named vector of results
 # this type of function is compatible with aggregate()
-.slab.fun.factor.default <- function(values, cpm) {
+.slab.fun.factor.default <- function(values, cpm, ...) {
 
   if (cpm == 1) {
 	  # probabilities are relative to number of contributing profiles
@@ -25,24 +25,24 @@
 	return(pt)
 }
 
-.slab.fun.factor.weighted <- function(values, w) {
+.slab.fun.factor.weighted <- function(values, w, na.rm = TRUE, ...) {
   # TODO
 }
   
 # default slab function for continuous variables
 # returns a named vector of results
 # this type of function is compatible with aggregate()
-.slab.fun.numeric.default <- function(values, probs = c(0.05, 0.25, 0.5, 0.75, 0.95)) {
-  .slab.fun.numeric.fast(values, probs = probs)
+.slab.fun.numeric.default <- function(values, probs = c(0.05, 0.25, 0.5, 0.75, 0.95), na.rm = TRUE, ...) {
+  .slab.fun.numeric.fast(values, probs = probs, na.rm = na.rm, ...)
 }
 
 # for a site or horizon level weight column, use Hmisc::wtd.quantile
 #   note that "frequency weights" are assumed to be most common use case, so normwt=FALSE by default, 
 #   normwt=TRUE can be passed as optional argument for slab.fun from slab() interface
-.slab.fun.numeric.weighted <- function(values, w, probs = c(0.05, 0.25, 0.5, 0.75, 0.95), normwt = FALSE) {
+.slab.fun.numeric.weighted <- function(values, w, probs = c(0.05, 0.25, 0.5, 0.75, 0.95), normwt = FALSE, na.rm = TRUE, ...) {
   if (!requireNamespace('Hmisc', quietly = TRUE))
     stop('please install the `Hmisc` package to use `wtd.quantile()` method', call. = FALSE)
-  res <- try(Hmisc::wtd.quantile(values, w, probs = probs, na.rm = TRUE, normwt = normwt), silent = TRUE)
+  res <- try(Hmisc::wtd.quantile(values, w, probs = probs, na.rm = na.rm, normwt = normwt), silent = TRUE)
   if (inherits(res, 'try-error') && grepl("zero non-NA points", res[1])) {
     res <- rep(NA_real_, length(probs))
   } else {
@@ -52,20 +52,20 @@
 }
 
 # easy specification of Hmisc::hdquantile if available
-.slab.fun.numeric.HD <- function(values, probs = c(0.05, 0.25, 0.5, 0.75, 0.95)) {
+.slab.fun.numeric.HD <- function(values, probs = c(0.05, 0.25, 0.5, 0.75, 0.95), na.rm = TRUE, ...) {
   # sanity check, need this for color distance eval
   if (!requireNamespace('Hmisc', quietly = TRUE))
     stop('please install the `Hmisc` package to use `hdquantile()` method', call. = FALSE)
   
-  res <- Hmisc::hdquantile(values, probs = probs, na.rm = TRUE)
+  res <- Hmisc::hdquantile(values, probs = probs, na.rm = na.rm)
   
   names(res) <- paste('p.q', round(probs * 100), sep = '')
   return(res)
 }
 
 # basic quantile evaluation, better for large data sets
-.slab.fun.numeric.fast <- function(values, probs = c(0.05, 0.25, 0.5, 0.75, 0.95)) {
-  res <- quantile(values, probs = probs, na.rm = TRUE)
+.slab.fun.numeric.fast <- function(values, probs = c(0.05, 0.25, 0.5, 0.75, 0.95), na.rm = TRUE, ...) {
+  res <- quantile(values, probs = probs, na.rm = na.rm)
   names(res) <- paste('p.q', round(probs * 100), sep = '')
   return(res)
 }
@@ -238,7 +238,7 @@
 	    FUN <- slab.fun
 	  }
 	  wt <- eval(weights)
-	  d.slabbed <- as.data.frame(d.long[, as.data.frame(t(FUN(value, .SD[[wt]]))), by = c('variable', g, 'seg.label')])
+	  d.slabbed <- as.data.frame(d.long[, as.data.frame(t(FUN(value, .SD[[wt]], ...))), by = c('variable', g, 'seg.label')])
 	  d.slabbed$contributing_fraction <- d.long[, sum(!is.na(.SD[["value"]])) / .N, by = c('variable', g, 'seg.label')]$V1
 
 	} else {

--- a/man/dice.Rd
+++ b/man/dice.Rd
@@ -11,7 +11,8 @@ dice(
   pctMissing = FALSE,
   fill = FALSE,
   strict = TRUE,
-  byhz = FALSE
+  byhz = FALSE,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ dice(
 \item{strict}{perform horizon depth logic checking / flagging / removal}
 
 \item{byhz}{Evaluate horizon depth logic at the horizon level (\code{TRUE}) or profile level (\code{FALSE}). Invalid depth logic invokes \code{HzDepthLogicSubset} which removes offending profiles or horizon records.}
+
+\item{verbose}{Print information about object size/memory usage. Default: \code{FALSE}}
 }
 \value{
 a \code{SoilProfileCollection} object, or \code{data.frame} when \code{SPC = FALSE}

--- a/man/slab-methods.Rd
+++ b/man/slab-methods.Rd
@@ -15,13 +15,15 @@
   fm,
   slab.structure = 1,
   strict = FALSE,
-  slab.fun = slab_function(method = "default"),
+  slab.fun = slab_function(method = "numeric"),
   cpm = 1,
   weights = NULL,
   ...
 )
 
-slab_function(method = c("default", "factor", "hd", "weighted", "fast"))
+slab_function(
+  method = c("numeric", "factor", "hd", "weighted.numeric", "weighted.factor", "fast")
+)
 }
 \arguments{
 \item{object}{a SoilProfileCollection}
@@ -49,7 +51,7 @@ to the contributing fraction, while mode 2 values will always sum to 1.}
 
 \item{\dots}{further arguments passed to \code{slab.fun}}
 
-\item{method}{one of \code{"default"}, \code{"factor"}, \code{"hd"}, \code{"weighted"}, \code{"fast"}}
+\item{method}{one of \code{"numeric"}, \code{"factor"}, \code{"hd"}, \code{"weighted.numeric"}, \code{"weighted.factor"}, \code{"fast"}}
 }
 \value{
 Output is returned in long format, such that slice-wise aggregates
@@ -124,7 +126,7 @@ units} \item{a vector of 3 or more integers}{e.g. c(0, 5, 10, 50, 100): data
 are aggregated over the depths spanning 0--5, 5--10, 10--50, 50--100 units}
 }
 
-\code{slab_function()}: The \code{"default"} aggregation method is the \code{"fast"} numeric (quantile) method. Additional methods include \code{"factor"} for categorical data, \code{"hd"} to use the Harrell-Davis Distribution-Free Quantile Estimator from the Hmisc package, and "\code{weighted}" to use a weighted quantile method from the Hmisc package
+\code{slab_function()}: The default \code{"numeric"} aggregation method is the \code{"fast"} numeric (quantile) method. Additional methods include \code{"factor"} for categorical data, \code{"hd"} to use the Harrell-Davis Distribution-Free Quantile Estimator from the Hmisc package, and "\code{weighted}" to use a weighted quantile method from the Hmisc package
 }
 \note{
 Arguments to \code{slab} have changed with \code{aqp} 1.5 (2012-12-29)

--- a/man/slab-methods.Rd
+++ b/man/slab-methods.Rd
@@ -7,6 +7,7 @@
 \alias{slab2}
 \alias{genSlabLabels}
 \alias{slab,SoilProfileCollection-method}
+\alias{slab_function}
 \title{Slab-Wise Aggregation of SoilProfileCollection Objects}
 \usage{
 \S4method{slab}{SoilProfileCollection}(
@@ -14,11 +15,13 @@
   fm,
   slab.structure = 1,
   strict = FALSE,
-  slab.fun = .slab.fun.numeric.default,
+  slab.fun = slab_function(method = "default"),
   cpm = 1,
   weights = NULL,
   ...
 )
+
+slab_function(method = c("default", "factor", "hd", "weighted", "fast"))
 }
 \arguments{
 \item{object}{a SoilProfileCollection}
@@ -42,9 +45,11 @@ either: number of profiles with data at the current slice (cpm=1), or by the
 number of profiles in the collection (cpm=2). Mode 1 values will always sum
 to the contributing fraction, while mode 2 values will always sum to 1.}
 
-\item{weights}{Column name containing weights. NOT YET IMPLEMENTED}
+\item{weights}{Column name containing site-level weights}
 
 \item{\dots}{further arguments passed to \code{slab.fun}}
+
+\item{method}{one of \code{"default"}, \code{"factor"}, \code{"hd"}, \code{"weighted"}, \code{"fast"}}
 }
 \value{
 Output is returned in long format, such that slice-wise aggregates
@@ -74,6 +79,8 @@ fraction of profiles contributing to the aggregate value, ranges from
 1/n_profiles to 1.}
 
 }
+
+\code{slab_function()}: return an aggregation function based on the \code{method} argument
 }
 \description{
 Aggregate soil properties along user-defined \code{slabs}, and optionally within
@@ -91,6 +98,8 @@ mean, mean-1SD and mean+1SD. The default slab function wraps
 \code{stats::quantile} from the Hmisc package, which requires at least 2
 observations per chunk. Note that if \code{group} is a factor it must not contain
 NAs.
+
+\code{slab()} uses \code{dice()} to "resample" profiles to 1cm slices from depth 0 to \code{max(x)} (or \code{slab.structure[2]}, if defined).
 
 Sometimes \code{slab} is used to conveniently re-arrange data vs. aggregate.
 This is performed by specifying \code{identity} in \code{slab.fun}. See
@@ -114,6 +123,8 @@ integers}{e.g. c(50, 60): data are aggregated over depths spanning 50--60
 units} \item{a vector of 3 or more integers}{e.g. c(0, 5, 10, 50, 100): data
 are aggregated over the depths spanning 0--5, 5--10, 10--50, 50--100 units}
 }
+
+\code{slab_function()}: The \code{"default"} aggregation method is the \code{"fast"} numeric (quantile) method. Additional methods include \code{"factor"} for categorical data, \code{"hd"} to use the Harrell-Davis Distribution-Free Quantile Estimator from the Hmisc package, and "\code{weighted}" to use a weighted quantile method from the Hmisc package
 }
 \note{
 Arguments to \code{slab} have changed with \code{aqp} 1.5 (2012-12-29)
@@ -190,7 +201,6 @@ xyplot(top ~ value | id, data=a, ylab='Depth',
        prepanel=prepanel.depth_function,
        scales=list(x=list(alternating=1))
 )
-
 
 ##
 ## categorical variable example

--- a/tests/testthat/test-slab.R
+++ b/tests/testthat/test-slab.R
@@ -119,6 +119,14 @@ test_that("extended slab functionality: weighted aggregation", {
   a.2 <- slab(x, ~ ph1to1h2o_r, slab.structure = c(0, 10), weights = "comppct_r")
   expect_equal(a.2$p.q50, 6.5)
   
+  # comppct_r adjusted to get lower result more like jokerst
+  x$comppct_r <- c(NA, 90)
+  na.1 <- slab(x, ~ ph1to1h2o_r, slab.structure = c(0, 10), weights = "comppct_r", na.rm = TRUE)
+  expect_equal(na.1$p.q50, 6.5)
+  
+  na.2 <- slab(x, ~ ph1to1h2o_r, slab.structure = c(0, 10), weights = "comppct_r", slab.fun = weighted.mean, na.rm = TRUE)
+  expect_equal(na.2$value, NA)
+  
 })
 
 test_that("slab calculations: mean, single profile", {

--- a/tests/testthat/test-slab.R
+++ b/tests/testthat/test-slab.R
@@ -35,7 +35,32 @@ test_that("basic slab functionality", {
   expect_true(any(grepl('p.q', nm)))
 })
 
-
+test_that("extended slab functionality: weighted aggregation", {
+  
+  data(sp1, package = 'aqp')
+  depths(sp1) <- id ~ top + bottom
+  
+  sp1$weights <- rep(1:2, length(sp1))[1:length(sp1)]
+  sp1$wtgrp <- rep(1, length(sp1))
+  
+  # we expect quantile estimates to vary (given weighted v.s. unweighted)
+  a.0 <- slab(sp1, fm = ~ prop, weights = "weights")
+  a.1 <- slab(sp1, fm = ~ prop, strict = TRUE, weights = "weights")
+  a.2 <- slab(sp1, fm = wtgrp ~ prop, strict = TRUE, weights = "weights")
+  a.3 <- slab(sp1, fm = wtgrp ~ prop, strict = TRUE)
+  
+  # expect consistent structure for weighted/unweighted: same column names except for group
+  ungroupcols <- colnames(a.3)
+  ungroupcols[2] <- "all.profiles"
+  expect_equal(colnames(a.0), ungroupcols)
+  expect_equal(colnames(a.1), ungroupcols)
+  expect_equal(colnames(a.2), colnames(a.3))
+  
+  # contributing fractions should be identical
+  expect_true(all(a.1$contributing_fraction == a.2$contributing_fraction))
+  expect_true(all(a.2$contributing_fraction == a.3$contributing_fraction))
+  
+})
 
 test_that("slab calculations: mean, single profile", {
   

--- a/tests/testthat/test-slab.R
+++ b/tests/testthat/test-slab.R
@@ -84,6 +84,41 @@ test_that("extended slab functionality: weighted aggregation", {
   expect_true(all(a.1$contributing_fraction == a.2$contributing_fraction))
   expect_true(all(a.2$contributing_fraction == a.3$contributing_fraction))
   
+  # component weighted averages
+  # mukey=461268; Doemill-Jokerst, 3 to 8 percent slopes (615)
+  x <- data.frame(cokey = c(21469960L, 21469960L, 21469960L, 21469960L, 
+                            21469960L, 21469961L, 21469961L, 21469961L), 
+                  comppct_r = c(50L,  50L, 50L, 50L, 50L, 40L, 40L, 40L),
+                  hzdept_r = c(0L, 3L, 13L, 23L, 36L, 0L, 3L, 10L), 
+                  hzdepb_r = c(3L, 13L, 23L, 36L, 61L, 3L, 10L, 35L), 
+                  ph1to1h2o_r = c(6.1, 6.8, 6.7, 6.7, NA, 6.4, 6.5, NA))
+  depths(x) <- cokey ~ hzdept_r + hzdepb_r
+  site(x) <- ~ comppct_r
+  
+  # custom function, with actual comppct_r
+  a.0 <- slab(x, ~ ph1to1h2o_r,
+      slab.structure = c(0, 10),
+      weights = "comppct_r",
+      slab.fun = weighted.mean,
+      na.rm = TRUE
+    )
+  expect_equal(a.0$value, 6.54, tolerance = 0.005) 
+  
+  # should match this within the tolerance:
+  #   soilDB::get_SDA_property(property = 'ph1to1h2o_r', method = "weighted average",
+  #                            mukeys = 461268, miscellaneous_areas = FALSE, include_minors = TRUE,
+  #                            top_depth = 0, bottom_depth = 10)
+                                  
+  # comppct_r adjusted to get higher result more like doemill
+  x$comppct_r <- c(90, 10)
+  a.1 <- slab(x, ~ ph1to1h2o_r, slab.structure = c(0, 10), weights = "comppct_r")
+  expect_equal(a.1$p.q50, 6.8)
+  
+  # comppct_r adjusted to get lower result more like jokerst
+  x$comppct_r <- c(10, 90)
+  a.2 <- slab(x, ~ ph1to1h2o_r, slab.structure = c(0, 10), weights = "comppct_r")
+  expect_equal(a.2$p.q50, 6.5)
+  
 })
 
 test_that("slab calculations: mean, single profile", {
@@ -93,7 +128,14 @@ test_that("slab calculations: mean, single profile", {
   
   # aggregate single profile
   # custom slabs
-  a <- slab(sp1[1, ], fm = ~ prop, strict=TRUE, slab.structure=c(0,5,10,25,100), slab.fun = mean, na.rm=TRUE)
+  a <- slab(
+      sp1[1,],
+      fm = ~ prop,
+      strict = TRUE,
+      slab.structure = c(0, 5, 10, 25, 100),
+      slab.fun = mean,
+      na.rm = TRUE
+    )
   
   # using mean and similar functions will cause slab to store single result / slab into 'value' column
   expect_true(any(grepl('value', names(a))))
@@ -101,13 +143,13 @@ test_that("slab calculations: mean, single profile", {
   # calculations done by hand (DEB)
   # weighted mean, single profile
   # 0-5: 9.400
-  expect_equal(a$value[1], 9.4, tolerance=0.0001)
+  expect_equal(a$value[1], 9.4, tolerance = 0.0001)
   # 5-10: 7.000
-  expect_equal(a$value[2], 7, tolerance=0.0001)
+  expect_equal(a$value[2], 7, tolerance = 0.0001)
   # 10-25: 8.466
-  expect_equal(a$value[3], 8.4666, tolerance=0.0001)
+  expect_equal(a$value[3], 8.4666, tolerance = 0.0001)
   # 25-100: 15.625
-  expect_equal(a$value[4], 15.625, tolerance=0.0001)
+  expect_equal(a$value[4], 15.625, tolerance = 0.0001)
   
 })
 

--- a/tests/testthat/test-slab.R
+++ b/tests/testthat/test-slab.R
@@ -1,7 +1,5 @@
 context("slab method for SoilProfileCollection objects")
 
-
-
 test_that("basic slab functionality", {
   
   data(sp1, package = 'aqp')
@@ -34,6 +32,32 @@ test_that("basic slab functionality", {
   expect_true(any(grepl('contributing_fraction', nm)))
   expect_true(any(grepl('p.q', nm)))
 })
+
+test_that("slab structure for a single slab", {
+  data(sp4, package = 'aqp')
+  depths(sp4) <- id ~ top + bottom
+  
+  sp4$group <- c(rep('A',5), rep('B',5))
+  a.1 <- slab(
+    sp4,
+    fm = ~ sand + silt + clay,
+    slab.structure = c(0, 10),
+    slab.fun = mean,
+    na.rm = TRUE
+  )
+  expect_equal(nrow(a.1), 3)
+  
+  # again, this time within groups defined by a site-level attribute:
+  a.1 <- slab(
+    sp4,
+    fm = group ~ sand + silt + clay,
+    slab.structure = c(0, 10),
+    slab.fun = mean,
+    na.rm = TRUE
+  )
+  expect_equal(nrow(a.1), 6)
+})
+
 
 test_that("extended slab functionality: weighted aggregation", {
   


### PR DESCRIPTION
These are some updates that resolve some tasks from #115, and implements #229

Notably, `slab()` now uses `dice()` so users will not get confused when they get a deprecation message RE: `slice()` while using `slab()`. I have had several questions from users about this (essentially: how do I use dice() with slab()?)

```r
library(aqp)
#> This is aqp 1.43
data(sp1, package = 'aqp')
depths(sp1) <- id ~ top + bottom
a.max <- slab(sp1, fm = ~ prop)
#> Note: aqp::slice() will be deprecated in aqp version 2.0
#> --> Please consider using the more efficient aqp::dice()
```

This PR has attempted to cover / ensure that the following are addressed:
 - issues related to the  `fm = 0:z ~ .` results in `z+1` slices (fixed insofar as they affect `slab()`, I don't think it is fully fixed on `dice()` side yet)
 - handled 0 thickness horizons in `slab()`, whether or not `strict=TRUE`
 - fixed mismatching lengths of slab labels v.s rows in data
 - added and exported `slab_function()` a helper method for accessing the internal slab methods provided by the package; now used in method definitions rather than internal functions (could use more documentation on arguments/patterns for custom functions, and ensuring extra arguments all works)
 - added a weighted variant of the numeric/quantile method via `Hmisc::wtd.quantile()`, and support for custom weighted functions (such as `weighted.mean()`)
 
I am sure this has not yet caught everything, but I spent some time ensuring all the existing tests worked, and added some more that stress a few other features, as well as new tests for the now-implemented `weights` argument. It all appears to be functioning as expected in the test cases, though I bet there are still edge cases or un-tested use cases that still have issues.