### PR TITLE
Fixing tests and issues with minimal install

### DIFF
--- a/R/mixMunsell.R
+++ b/R/mixMunsell.R
@@ -218,18 +218,18 @@ mixMunsell <- function(x, w = rep(1, times = length(x)) / length(x), mixingMetho
   mixingMethod <- match.arg(mixingMethod)
   
   # multiple matches only possible when using mixingMethod == 'reference'
-  if((n > 1) & mixingMethod != 'reference') {
+  if((n > 1) && mixingMethod != 'reference') {
     stop('`n` is only valid for `mixingMethod = "reference"`', call. = FALSE)
   }
   
   # mixed spectra and multiple matches only possible when using mixingMethod == 'reference'
-  if(keepMixedSpec & ! mixingMethod %in% c('reference', 'exact')) {
+  if(keepMixedSpec && !mixingMethod %in% c('reference', 'exact')) {
     stop('`keepMixedSpec` is only valid for mixingMethod = "reference" or "exact"', call. = FALSE)
   }
   
   # sanity check, need this for gower::gower_topn()
-  if(mixingMethod == 'reference' & !requireNamespace('gower')) {
-    stop('package `gower` is required for `reference` mixingMethod', call. = FALSE)
+  if(mixingMethod == 'reference' && !requireNamespace('gower')) {
+    stop("package `gower` is required for `mixingMethod='reference'`", call. = FALSE)
   }
   
 

--- a/tests/testthat/test-DT-tbl.R
+++ b/tests/testthat/test-DT-tbl.R
@@ -19,38 +19,38 @@ test_that("basic coercion", {
   }
 
   ### .as.data.frame.aqp wrapper on data.frames
-  expect_equal(aqp:::.as.data.frame.aqp(empty_df, "data.frame"), empty_df)
+  expect_equal(.as.data.frame.aqp(empty_df, "data.frame"), empty_df)
   ## data frame with 0 columns and 0 rows
 
-  expect_equal(aqp:::.as.data.frame.aqp(empty_df, "data.table"), empty_dt)
+  expect_equal(.as.data.frame.aqp(empty_df, "data.table"), empty_dt)
   ## Null data.table (0 rows and 0 cols)
 
-  expect_equal(aqp:::.as.data.frame.aqp(empty_df, "tbl_df"), empty_tb)
+  expect_equal(.as.data.frame.aqp(empty_df, "tbl_df"), empty_tb)
   ## A tibble: 0 x 0
 
 
   # as.data.frame wrapper on tibbles
-  expect_equal(aqp:::.as.data.frame.aqp(empty_tb, "data.table"), empty_dt)
+  expect_equal(.as.data.frame.aqp(empty_tb, "data.table"), empty_dt)
   # Null data.table (0 rows and 0 cols)
   #
-  expect_equal(aqp:::.as.data.frame.aqp(empty_tb, "data.frame"), empty_df)
+  expect_equal(.as.data.frame.aqp(empty_tb, "data.frame"), empty_df)
   # data frame with 0 columns and 0 rows
   #
-  expect_equal(aqp:::.as.data.frame.aqp(empty_tb, "tbl_df"), empty_tb)
+  expect_equal(.as.data.frame.aqp(empty_tb, "tbl_df"), empty_tb)
   # A tibble: 0 x 0
 
   # as.data.frame wrapper on data.table
-  expect_equal(aqp:::.as.data.frame.aqp(empty_dt, "data.table"), empty_dt)
+  expect_equal(.as.data.frame.aqp(empty_dt, "data.table"), empty_dt)
   # Null data.table (0 rows and 0 cols)
 
-  expect_equal(aqp:::.as.data.frame.aqp(empty_dt, "data.frame"), empty_df)
+  expect_equal(.as.data.frame.aqp(empty_dt, "data.frame"), empty_df)
   # data frame with 0 columns and 0 rows
 
-  expect_equivalent(aqp:::.as.data.frame.aqp(empty_dt, "tbl_df"), empty_tb)
+  expect_equivalent(.as.data.frame.aqp(empty_dt, "tbl_df"), empty_tb)
   # note: that because of slight internal differences (leftover from data.table?)
   #       cannot use expect_equal -- though they are clearly equivalent
   #
-  # > str(aqp:::.as.data.frame.aqp(empty_dt, "tbl_df"))
+  # > str(.as.data.frame.aqp(empty_dt, "tbl_df"))
   # tibble [0 × 0] (S3: tbl_df/tbl/data.frame)
   # Named list()
   # - attr(*, ".internal.selfref")=<externalptr>
@@ -83,7 +83,7 @@ res <- lapply(dfclasses, function(use_class) {
 
     # basic function for converting inputs btween tibble and data.frame
     test_object <- function(object, use_class) {
-      aqp:::.as.data.frame.aqp(object, as.class = use_class)
+      .as.data.frame.aqp(object, as.class = use_class)
     }
 
     # make some fake data
@@ -133,7 +133,7 @@ res <- lapply(dfclasses, function(use_class) {
     expect_message(rebuildSPC(test2), "using `hzID` as a unique horizon ID")
 
     # test enforce_df_class
-    expect_silent(aqp:::.enforce_df_class(test2, use_class))
+    expect_silent(.enforce_df_class(test2, use_class))
 
     # "normalize" (horizon -> site) a site-level attribute
     site(test) <- ~ siteprop
@@ -276,7 +276,7 @@ res <- lapply(dfclasses, function(use_class) {
 
     ## make sample data using current class type
     data(sp1, package = 'aqp')
-    sp1df <- aqp:::.as.data.frame.aqp(sp1, use_class, stripFactors = TRUE)
+    sp1df <- .as.data.frame.aqp(sp1, use_class, stripFactors = TRUE)
     depths(sp1df) <- id ~ top + bottom
     site(sp1df) <- ~ group
 
@@ -342,7 +342,7 @@ res <- lapply(dfclasses, function(use_class) {
       # do it here
       h <- horizons(sp1df)
       s <- site(sp1df)
-      d <- aqp:::.as.data.frame.aqp(as(sp1df, 'data.frame'), use_class)
+      d <- .as.data.frame.aqp(as(sp1df, 'data.frame'), use_class)
 
       expect_true(inherits(h, use_class))
       expect_true(inherits(s, use_class))

--- a/tests/testthat/test-NCSP.R
+++ b/tests/testthat/test-NCSP.R
@@ -97,7 +97,7 @@ test_that(".NCSP_distanceCalc() with color data", {
   sm <- rep(TRUE, times = nrow(.lab))
   
   # CIE2000 color contrast
-  d <- aqp:::.NCSP_distanceCalc(.lab, sm = sm, isColor = TRUE)
+  d <- .NCSP_distanceCalc(.lab, sm = sm, isColor = TRUE)
   
   # results should be 3x3 distance matrix
   # not created by cluster package, plain old dist object

--- a/tests/testthat/test-SPC-combine.R
+++ b/tests/testthat/test-SPC-combine.R
@@ -54,15 +54,15 @@ test_that("non-conformal combination tests", {
 
   # random data
   ids <- sprintf("%02d", 1:5)
-  x <- plyr::ldply(ids, random_profile, n=c(6, 7, 8), n_prop=1, method='LPP',
-                   lpp.a=5, lpp.b=15, lpp.d=5, lpp.e=5, lpp.u=25)
+  x <- do.call('rbind', lapply(ids, random_profile, n=c(6, 7, 8), n_prop=1, method='LPP',
+                   lpp.a=5, lpp.b=15, lpp.d=5, lpp.e=5, lpp.u=25))
 
   depths(x) <- id ~ top + bottom
 
   # more random data
   ids <- sprintf("%s", letters[1:5])
-  y <- plyr::ldply(ids, random_profile, n=c(6, 7, 8), n_prop=4, method='LPP',
-                   lpp.a=5, lpp.b=15, lpp.d=5, lpp.e=5, lpp.u=25)
+  y <- do.call('rbind', lapply(ids, random_profile, n=c(6, 7, 8), n_prop=4, method='LPP',
+                   lpp.a=5, lpp.b=15, lpp.d=5, lpp.e=5, lpp.u=25))
 
   # alter ID, top, bottom column names
   y$pID <- y$id

--- a/tests/testthat/test-aqp.R
+++ b/tests/testthat/test-aqp.R
@@ -4,5 +4,4 @@ test_that("defaults", {
   expect_equal(getOption(".aqp.show.n.cols"), 10)
   options(.aqp.show.n.cols = 100)
   expect_equal(getOption(".aqp.show.n.cols"), 100)
-  expect_silent(aqp:::.onLoad("foo","bar")) # libname and pkgname not used at present
 })

--- a/tests/testthat/test-color-conversion.R
+++ b/tests/testthat/test-color-conversion.R
@@ -59,28 +59,28 @@ test_that("parseMunsell()", {
 test_that("Munsell hue parsing", {
 
   # normal operation
-  res <- aqp:::.parseMunsellHue('10YR')
+  res <- .parseMunsellHue('10YR')
   expect_true(inherits(res, 'data.frame'))
   expect_equal(res$hue.numeric, 10L)
   expect_equal(res$hue.character, 'YR')
   expect_equal(nrow(res), 1)
 
   # white space is trimmed
-  res <- aqp:::.parseMunsellHue('10 YR')
+  res <- .parseMunsellHue('10 YR')
   expect_true(inherits(res, 'data.frame'))
   expect_equal(res$hue.numeric, 10L)
   expect_equal(res$hue.character, 'YR')
   expect_equal(nrow(res), 1)
   
   # decimal, won't convert correctly, but should be split
-  res <- aqp:::.parseMunsellHue('10.1YR')
+  res <- .parseMunsellHue('10.1YR')
   expect_true(inherits(res, 'data.frame'))
   expect_equal(res$hue.numeric, 10.1)
   expect_equal(res$hue.character, 'YR')
   expect_equal(nrow(res), 1)
   
   # bogus hue
-  res <- aqp:::.parseMunsellHue('G1 ')
+  res <- .parseMunsellHue('G1 ')
   expect_true(inherits(res, 'data.frame'))
   expect_true(is.na(res$hue.numeric))
   expect_true(is.na(res$hue.character))

--- a/tests/testthat/test-mixMunsell.R
+++ b/tests/testthat/test-mixMunsell.R
@@ -1,8 +1,8 @@
 context("mixing Munsell colors")
 
-# skip_if_not_installed('gower')
-
 test_that("mixMunsell works as expected", {
+  
+  skip_if_not_installed('gower')
   
   ## error conditions
   expect_error(mixMunsell(c(NA, '10YR 3/4')))
@@ -26,14 +26,16 @@ test_that("mixMunsell works as expected", {
   # 1 10YR 4/2 1.955568
   
   x <- mixMunsell(c('10YR 5/3', '10YR 3/2'), w = 1)
-  expect_true(x$munsell == '10YR 4/2')
+  expect_equal(x$munsell, '10YR 4/2')
   expect_equal(x$distance, 1.9555, tolerance = 1e-4)
 
   # weights when length(x) != length(unique(x))
-  expect_silent(mixMunsell(c('10YR 5/3', '10YR 3/2', '10YR 5/3')))
+  expect_equal(mixMunsell(c('10YR 5/3', '10YR 3/2', '10YR 5/3'))$munsell,
+               "10YR 4/3")
 
   # 0 weights to filter NA
-  expect_silent(mixMunsell(c(NA, '10YR 3/4'), w = c(0, 1)))
+  expect_equal(mixMunsell(c(NA, '10YR 3/4'), w = c(0, 1))$munsell,
+               "10YR 3/4")
 
 })
 

--- a/tests/testthat/test-mixMunsell.R
+++ b/tests/testthat/test-mixMunsell.R
@@ -2,8 +2,6 @@ context("mixing Munsell colors")
 
 test_that("mixMunsell works as expected", {
   
-  skip_if_not_installed('gower')
-  
   ## error conditions
   expect_error(mixMunsell(c(NA, '10YR 3/4')))
 

--- a/tests/testthat/test-plotSPC.R
+++ b/tests/testthat/test-plotSPC.R
@@ -246,17 +246,20 @@ test_that("horizon color specification interpreted correctly", {
   h <- horizons(p)
   
   # colors to use
-  cols <- c("#5E4FA2", "#3288BD", "#66C2A5","#ABDDA4", "#E6F598", "#FEE08B","#FDAE61", "#F46D43", "#D53E4F","#9E0142")
+  cols <- c("#5E4FA2", "#3288BD", "#66C2A5",
+            "#ABDDA4", "#E6F598", "#FEE08B",
+            "#FDAE61", "#F46D43", "#D53E4F",
+            "#9E0142")
   
   # attempt to interpret
-  x <- aqp:::.interpretHorizonColor(
-    h, 
-    color = 'p1', 
-    default.color = 'grey', 
+  x <- .interpretHorizonColor(
+    h,
+    color = 'p1',
+    default.color = 'grey',
     col.palette = cols,
     col.palette.bias = 1,
     n.legend = 8
-    )
+  )
   
   # reasonable object?
   expect_true(inherits(x, 'list'))
@@ -266,7 +269,7 @@ test_that("horizon color specification interpreted correctly", {
   expect_null(x$color.legend.data$leg.row.indices)
   
   # another try, no colors specified
-  x <- aqp:::.interpretHorizonColor(
+  x <- .interpretHorizonColor(
     h, 
     color = NA, 
     default.color = 'grey', 
@@ -281,9 +284,8 @@ test_that("horizon color specification interpreted correctly", {
   # there is no legend
   expect_true(is.null(x$color.legend.data))
   
-  
   # factor variable + multi-line legend
-  x <- aqp:::.interpretHorizonColor(
+  x <- .interpretHorizonColor(
     h, 
     color = 'p.factor', 
     default.color = 'grey', 

--- a/tests/testthat/test-profile_compare.R
+++ b/tests/testthat/test-profile_compare.R
@@ -35,6 +35,8 @@ site(d) <- s
 
 test_that("profile_compare works as expected", {
   
+  skip_if_not_installed("scales")
+  
   # compute between-profile dissimilarity, no depth weighting
   # warning is expected because this is deprecated
   expect_warning({

--- a/tests/testthat/test-slab.R
+++ b/tests/testthat/test-slab.R
@@ -67,23 +67,6 @@ test_that("extended slab functionality: weighted aggregation", {
   sp1$weights <- rep(1:2, length(sp1))[1:length(sp1)]
   sp1$wtgrp <- rep(1, length(sp1))
   
-  # we expect quantile estimates to vary (given weighted v.s. unweighted)
-  a.0 <- slab(sp1, fm = ~ prop, weights = "weights")
-  a.1 <- slab(sp1, fm = ~ prop, strict = TRUE, weights = "weights")
-  a.2 <- slab(sp1, fm = wtgrp ~ prop, strict = TRUE, weights = "weights")
-  a.3 <- slab(sp1, fm = wtgrp ~ prop, strict = TRUE)
-  
-  # expect consistent structure for weighted/unweighted: same column names except for group
-  ungroupcols <- colnames(a.3)
-  ungroupcols[2] <- "all.profiles"
-  expect_equal(colnames(a.0), ungroupcols)
-  expect_equal(colnames(a.1), ungroupcols)
-  expect_equal(colnames(a.2), colnames(a.3))
-  
-  # contributing fractions should be identical
-  expect_true(all(a.1$contributing_fraction == a.2$contributing_fraction))
-  expect_true(all(a.2$contributing_fraction == a.3$contributing_fraction))
-  
   # component weighted averages
   # mukey=461268; Doemill-Jokerst, 3 to 8 percent slopes (615)
   x <- data.frame(cokey = c(21469960L, 21469960L, 21469960L, 21469960L, 
@@ -103,6 +86,25 @@ test_that("extended slab functionality: weighted aggregation", {
       na.rm = TRUE
     )
   expect_equal(a.0$value, 6.54, tolerance = 0.005) 
+  
+  skip_if_not_installed("Hmisc")
+  
+  # we expect quantile estimates to vary (given weighted v.s. unweighted)
+  a.0 <- slab(sp1, fm = ~ prop, weights = "weights")
+  a.1 <- slab(sp1, fm = ~ prop, strict = TRUE, weights = "weights")
+  a.2 <- slab(sp1, fm = wtgrp ~ prop, strict = TRUE, weights = "weights")
+  a.3 <- slab(sp1, fm = wtgrp ~ prop, strict = TRUE)
+  
+  # expect consistent structure for weighted/unweighted: same column names except for group
+  ungroupcols <- colnames(a.3)
+  ungroupcols[2] <- "all.profiles"
+  expect_equal(colnames(a.0), ungroupcols)
+  expect_equal(colnames(a.1), ungroupcols)
+  expect_equal(colnames(a.2), colnames(a.3))
+  
+  # contributing fractions should be identical
+  expect_true(all(a.1$contributing_fraction == a.2$contributing_fraction))
+  expect_true(all(a.2$contributing_fraction == a.3$contributing_fraction))
   
   # should match this within the tolerance:
   #   soilDB::get_SDA_property(property = 'ph1to1h2o_r', method = "weighted average",


### PR DESCRIPTION
Some notes/fixes from testing on a fresh machine with a minimal set of dependencies.
 - removes {scales} dependency from `plotSPC()`
 - removes {plyr} usage from test-SPC-combine.R
 - <strike>skip `mixMunsell()` tests if {gower} not installed</strike>
   fixed bad logic that required {gower} for `mixMunsell(..., mixingMethod="exact")`
 - avoid usage of `aqp:::` in tests
 - skip `profile_compare()` (deprecated) tests if {scales} is not installed
 - skip some `slab()` tests if {Hmisc} is not installed