### PR TITLE
`split()`: allow `NA`->`"<missing>"` levels

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -76,6 +76,13 @@ setMethod("split",
       # extract to local variable, so as not to modify original data
       fg <- x[[f]]
       
+      # all NA, empty list is the result
+      if(all(is.na(fg)) && drop) {
+        message('all groups have been dropped due to NA')
+        # nothing left to do
+        return(list())
+      }
+      
       # no NA allowed
       if (any(is.na(fg)) && !drop) {
         fg[is.na(fg)] <- "<missing>"
@@ -85,7 +92,6 @@ setMethod("split",
       if (!inherits(fg, 'factor')) {
         fg <- factor(fg)
         message(sprintf('converting %s to factor', f))
-        print(fg)
       }
   
     # using a vector coercible to factor (like base::split)

--- a/R/split.R
+++ b/R/split.R
@@ -92,6 +92,9 @@ setMethod("split",
 
       # preserve NA levels as missing
       if (any(is.na(f)) && !drop) {
+        if (is.factor(f)) {
+         levels(f) <- c(levels(f), "<missing>")
+        }
         f[is.na(f)] <- "<missing>"
       }
 
@@ -105,6 +108,9 @@ setMethod("split",
       # preserve NA levels as missing
       f <- lapply(f, function(ff) {
         if (any(is.na(ff)) && !drop) {
+          if (is.factor(ff)) {
+            levels(ff) <- c(levels(ff), "<missing>")
+          }
           ff[is.na(ff)] <- "<missing>"
         }
         ff
@@ -116,10 +122,6 @@ setMethod("split",
     } else {
       stop(sprintf('invalid argument `f`'), call. = FALSE)
     }
-  }
-
-  if (drop) {
-    fg <- droplevels(fg)
   }
 
   # iterate over levels

--- a/R/split.R
+++ b/R/split.R
@@ -10,20 +10,20 @@
 #                                 aqp =     { split(loafercreek, "pmorigin") })
 #
 
-#' Split a SoilProfileCollection object into a list of SoilProfileCollection objects.
+#' @title Split a SoilProfileCollection object into a list of SoilProfileCollection objects.
 #'
-#' This function splits a SoilProfileCollection into a list of SoilProfileCollection objects using a site-level attribute to define groups or profile ID (idname(x)).
+#' @description This function splits a `SoilProfileCollection` into a list of `SoilProfileCollection` objects using a site-level attribute to define groups or profile ID (`idname(x)`).
 #'
-#' @param x a SoilProfileCollection object
-#' @param f a character vector naming a single site-level attribute that defines groups, a ‘factor’ in the sense that \code{as.factor(f)} defines the grouping, or a list of such factors in which case their interaction is used for the grouping.
+#' @param x a `SoilProfileCollection` object
+#' @param f a character vector naming a single site-level attribute that defines groups, a ‘factor’ in the sense that `as.factor(f)` defines the grouping, or a list of such factors in which case their interaction is used for the grouping.
 #' @param drop logical indicating if levels that do not occur should be dropped (if f is a factor or a list). When `drop=FALSE` and `f` contains missing values an additional group "<missing>" is returned.
 #' @param ...	Additional arguments are ignored
 #'
-#' @details As of aqp 1.25, omission of `f` argument is no longer possible, as the base R generic is overloaded by this SoilProfileCollection method. This used to result in an "identity" split, according to \code{idname(x)}, e.g. a list as long as \code{length(x)}, with a single-profile SoilProfileCollection per list element. Replicate this behavior using \code{f = idname(x)} or \code{f = profile_id(x)}
+#' @details As of aqp 1.25, omission of `f` argument is no longer possible, as the base R generic is overloaded by this `SoilProfileCollection` method. This used to result in an "identity" split, according to `idname(x)`, e.g. a list as long as `length(x)`, with a single-profile `SoilProfileCollection` per list element. Replicate this behavior using `f = idname(x)` or `f = profile_id(x)`.
 #'
-#' @author D.E Beaudette
+#' @author D.E. Beaudette and A.G. Brown
 #'
-#' @return A list of SoilProfileCollections or \code{NULL} for empty result.
+#' @return A list of `SoilProfileCollection` or `NULL` for empty result.
 #' @export
 #'
 #' @examples
@@ -58,7 +58,7 @@ setMethod("split",
           signature(x = "SoilProfileCollection", f = "ANY"),
           function(x, f, drop = TRUE, ...) {
 
-  # identity split, use idname
+  # identity split, use idname()
   if (is.null(f)) {
 
     # grouping factor, make sure to use original ordering
@@ -85,8 +85,9 @@ setMethod("split",
       if (!inherits(fg, 'factor')) {
         fg <- factor(fg)
         message(sprintf('converting %s to factor', f))
+        print(fg)
       }
-
+  
     # using a vector coercible to factor (like base::split)
     } else if (length(f) == length(x) && !is.list(f)) {
 

--- a/man/split-SoilProfileCollection-method.Rd
+++ b/man/split-SoilProfileCollection-method.Rd
@@ -11,7 +11,7 @@
 
 \item{f}{a character vector naming a single site-level attribute that defines groups, a ‘factor’ in the sense that \code{as.factor(f)} defines the grouping, or a list of such factors in which case their interaction is used for the grouping.}
 
-\item{drop}{logical indicating if levels that do not occur should be dropped (if f is a factor or a list).}
+\item{drop}{logical indicating if levels that do not occur should be dropped (if f is a factor or a list). When \code{drop=FALSE} and \code{f} contains missing values an additional group "\if{html}{\out{<missing>}}" is returned.}
 
 \item{...}{Additional arguments are ignored}
 }

--- a/man/split-SoilProfileCollection-method.Rd
+++ b/man/split-SoilProfileCollection-method.Rd
@@ -7,7 +7,7 @@
 \S4method{split}{SoilProfileCollection}(x, f, drop = TRUE, ...)
 }
 \arguments{
-\item{x}{a SoilProfileCollection object}
+\item{x}{a \code{SoilProfileCollection} object}
 
 \item{f}{a character vector naming a single site-level attribute that defines groups, a ‘factor’ in the sense that \code{as.factor(f)} defines the grouping, or a list of such factors in which case their interaction is used for the grouping.}
 
@@ -16,13 +16,13 @@
 \item{...}{Additional arguments are ignored}
 }
 \value{
-A list of SoilProfileCollections or \code{NULL} for empty result.
+A list of \code{SoilProfileCollection} or \code{NULL} for empty result.
 }
 \description{
-This function splits a SoilProfileCollection into a list of SoilProfileCollection objects using a site-level attribute to define groups or profile ID (idname(x)).
+This function splits a \code{SoilProfileCollection} into a list of \code{SoilProfileCollection} objects using a site-level attribute to define groups or profile ID (\code{idname(x)}).
 }
 \details{
-As of aqp 1.25, omission of \code{f} argument is no longer possible, as the base R generic is overloaded by this SoilProfileCollection method. This used to result in an "identity" split, according to \code{idname(x)}, e.g. a list as long as \code{length(x)}, with a single-profile SoilProfileCollection per list element. Replicate this behavior using \code{f = idname(x)} or \code{f = profile_id(x)}
+As of aqp 1.25, omission of \code{f} argument is no longer possible, as the base R generic is overloaded by this \code{SoilProfileCollection} method. This used to result in an "identity" split, according to \code{idname(x)}, e.g. a list as long as \code{length(x)}, with a single-profile \code{SoilProfileCollection} per list element. Replicate this behavior using \code{f = idname(x)} or \code{f = profile_id(x)}.
 }
 \examples{
 
@@ -54,5 +54,5 @@ length(p4) # 5 unique "surfaces", 5 SPCs in result list
 
 }
 \author{
-D.E Beaudette
+D.E. Beaudette and A.G. Brown
 }

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -56,6 +56,26 @@ test_that("split fails as expected", {
   expect_error(split(sp6, f = 'XXX'))
 })
 
-## warnings
-
-
+test_that("split with NA values in `f`", {
+  
+  site(sp6)$grp1 <- c(1, 1, 2, 2, NA, NA)
+  site(sp6)$grp2 <- c(1, 2, 1, 2,  1,  2)
+  
+  # no more error
+  x <- split(sp6, sp6$grp1)
+  expect_equal(length(x), 2)
+  
+  # additional "<missing>" group (with drop=FALSE)
+  x <- split(sp6, "grp1", drop = FALSE)
+  expect_equal(length(x), 3)
+  expect_equal(length(x[["<missing>"]]), 2)
+  
+  # interaction grp1*grp2
+  x <- split(sp6, list(sp6$grp1, sp6$grp2))
+  expect_equal(length(x), 4)
+  
+  # interaction grp1*grp2 (with drop=FALSE)
+  x <- split(sp6, list(sp6$grp1, sp6$grp2), drop = FALSE)
+  expect_equal(length(x), 6)
+  
+}) 

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -26,6 +26,23 @@ test_that("site-level grouping factor", {
   
 })
 
+test_that("site-level grouping factor, as a vector", {
+  
+  # standard, grouping factor
+  s <- split(sp6, sp6$g)
+  
+  # result should be a list
+  expect_true(inherits(s, 'list'))
+  
+  # expected groups
+  expect_true(length(s) == 2)
+  expect_equal(names(s), levels(sp6$g))
+  
+  # three profiles / group
+  expect_equivalent(sapply(s, length), c(3, 3))
+  
+})
+
 test_that("identity split", {
   
   # idname used
@@ -77,7 +94,7 @@ test_that("split with NA values in `f`", {
   # three groups
   expect_equal(length(x), 3)
   # check for special NA group
-  expect_equal(names(x), c('<missing>', c('1', '2')))
+  expect_true('<missing>' %in% names(x))
   # all groups have 2 members
   expect_true(all(sapply(x, length) == 2))
   

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -5,7 +5,7 @@ data(sp6)
 depths(sp6) <- id ~ top + bottom
 
 # fake grouping var
-sp6$g <- factor(rep(c('A', 'B'), each=3))
+sp6$g <- factor(rep(c('A', 'B'), each = 3))
 
 ## tests
 
@@ -17,11 +17,13 @@ test_that("site-level grouping factor", {
   # result should be a list
   expect_true(inherits(s, 'list'))
   
-  # two goups
+  # expected groups
   expect_true(length(s) == 2)
+  expect_equal(names(s), levels(sp6$g))
   
   # three profiles / group
-  expect_equivalent(sapply(s, length), c(3,3))
+  expect_equivalent(sapply(s, length), c(3, 3))
+  
 })
 
 test_that("identity split", {
@@ -61,14 +63,22 @@ test_that("split with NA values in `f`", {
   site(sp6)$grp1 <- c(1, 1, 2, 2, NA, NA)
   site(sp6)$grp2 <- c(1, 2, 1, 2,  1,  2)
   
-  # no more error
+  # profiles with NA are dropped
   x <- split(sp6, sp6$grp1)
+  # two groups
   expect_equal(length(x), 2)
+  # 4/6 profiles remain
+  expect_equal(sum(sapply(x, length)), 4)
+  
   
   # additional "<missing>" group (with drop=FALSE)
   x <- split(sp6, "grp1", drop = FALSE)
+  # three groups
   expect_equal(length(x), 3)
-  expect_equal(length(x[["<missing>"]]), 2)
+  # check for special NA group
+  expect_equal(names(x), c('<missing>', c('1', '2')))
+  # all groups have 2 members
+  expect_true(all(sapply(x, length) == 2))
   
   # interaction grp1*grp2
   x <- split(sp6, list(sp6$grp1, sp6$grp2))

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -62,6 +62,7 @@ test_that("split with NA values in `f`", {
   
   site(sp6)$grp1 <- c(1, 1, 2, 2, NA, NA)
   site(sp6)$grp2 <- c(1, 2, 1, 2,  1,  2)
+  site(sp6)$grp3 <- rep(NA_character_, times = length(sp6))
   
   # profiles with NA are dropped
   x <- split(sp6, sp6$grp1)
@@ -87,5 +88,17 @@ test_that("split with NA values in `f`", {
   # interaction grp1*grp2 (with drop=FALSE)
   x <- split(sp6, list(sp6$grp1, sp6$grp2), drop = FALSE)
   expect_equal(length(x), 6)
+  
+  ## all NA, not sure why this would happen...
+  
+  # all NA, empty list is the result
+  x <- split(sp6, 'grp3', drop = TRUE)
+  expect_true(inherits(x, 'list'))
+  expect_equal(length(x), 0)
+  
+  # single <missing> group 
+  x <- split(sp6, 'grp3', drop = FALSE)
+  expect_equal(names(x), '<missing>')
+  expect_equal(as.vector(sapply(x, length)), 6)
   
 }) 


### PR DESCRIPTION
`split()` allows `NA` levels (and preserves them as `"<missing>"` when `drop=FALSE`)

``` r
library(aqp)
#> This is aqp 2.0
data("jacobs2000")
site(jacobs2000)$grp1 <- c(1, 1, 1, 2, 2, NA, NA)
site(jacobs2000)$grp2 <- c(1, 2, 1, 2, 1, 2, 1)

# no more error
x <- split(jacobs2000, jacobs2000$grp1)
length(x)
#> [1] 2

# additional "<missing>" group
x <- split(jacobs2000, "grp1", drop = FALSE)
#> converting grp1 to factor
length(x)
#> [1] 3
length(x[["<missing>"]])
#> [1] 2

# interaction 
x <- split(jacobs2000, list(jacobs2000$grp1, jacobs2000$grp2))
length(x)
#> [1] 4

# interaction (with drop=FALSE)
x <- split(jacobs2000, list(jacobs2000$grp1, jacobs2000$grp2), drop = FALSE)
length(x)
#> [1] 6
names(x)
#> [1] "<missing>.1" "1.1"         "2.1"         "<missing>.2" "1.2"        
#> [6] "2.2"

# interaction (with factor with unused levels and drop=FALSE)
jacobs2000$grp3 <- factor(jacobs2000$grp2, levels = 1:10)
x <- split(jacobs2000, list(jacobs2000$grp1, jacobs2000$grp3), drop = FALSE)
length(x)
#> [1] 30
```
