### PR TITLE
Fix examples for `slab()`

### DIFF
--- a/R/slab-utils.R
+++ b/R/slab-utils.R
@@ -96,23 +96,23 @@ genSlabLabels <- function(slab.structure = 1, max.d = NULL, n.profiles = NULL, s
   
   # calculate a sequence of cumulative depths and corresponding indices for each slab
   j <- diff(i)
+  hzd <- horizonDepths(spc)
   if (length(j) == 0) {
     stop("Empty slab.structure", call. = FALSE)
-  } else if(length(j) == 1 && j == 0) {
+  } else if (length(j) == 1 && j == 0) {
     stop("Invalid slab.structure", call. = FALSE)
   } else {
-    idx1 <- cumsum(do.call('c', lapply(seq_along(j), function(x) rep(1, j[x]))))
+    idx1 <- cumsum(do.call('c', lapply(seq_along(j), function(x) rep(1, j[x])))) + i[1]
     idx2 <- do.call('c', lapply(seq_along(j), function(x) rep(x, j[x])))
     mt <- data.frame(idx1, slab_id = idx2, slab_label = paste0(i[idx2], "-", i[idx2 + 1]))
   }
-  hzdepb <- horizonDepths(spc)[2]
-  colnames(mt) <- c(hzdepb, "slab_id", "slab_label")
+  colnames(mt) <- c(hzd[2], "slab_id", "slab_label")
   
   # merge the dice'd data.frame result with the slab ID and labels
-  res <- merge(diced, mt, by = hzdepb, all.x = TRUE, sort = FALSE)
+  res <- merge(diced, mt, by = hzd[2], all.x = TRUE, sort = FALSE)
   
   # order by horizon ID and depth
-  res <- res[order(res[[idname(spc)]], res[[hzdepb]]),]
+  res <- res[order(res[[idname(spc)]], res[[hzd[2]]]),]
   
   # return the slab IDs as a factor, with labels denoting each segment top and bottom
   factor(res$slab_id, labels = na.omit(unique(res$slab_label)))

--- a/R/slab.R
+++ b/R/slab.R
@@ -560,7 +560,7 @@ setGeneric("slab", function(object,
 #'
 #'
 #' # apply slice-wise evaluation of max probability, and assign ML-horizon at each slice
-#' gen.hz.ml <- get.ml.hz(a, "variable", c('O','A','B','C'))
+#' gen.hz.ml <- get.ml.hz(a, c('O','A','B','C'))
 #'
 #'
 #' \dontrun{

--- a/R/slab.R
+++ b/R/slab.R
@@ -57,7 +57,7 @@
   if (!requireNamespace('Hmisc', quietly = TRUE))
     stop('please install the `Hmisc` package to use `hdquantile()` method', call. = FALSE)
   
-  res <- Hmisc::hdquantile(values, probs = probs, na.rm = na.rm)
+  res <- as.numeric(Hmisc::hdquantile(values, probs = probs, na.rm = na.rm))
   
   names(res) <- paste('p.q', round(probs * 100), sep = '')
   return(res)

--- a/man/slab.Rd
+++ b/man/slab.Rd
@@ -296,7 +296,7 @@ xyplot(top ~ value | variable,
 
 
 # apply slice-wise evaluation of max probability, and assign ML-horizon at each slice
-gen.hz.ml <- get.ml.hz(a, "variable", c('O','A','B','C'))
+gen.hz.ml <- get.ml.hz(a, c('O','A','B','C'))
 
 
 \dontrun{

--- a/tests/testthat/test-slab.R
+++ b/tests/testthat/test-slab.R
@@ -215,6 +215,39 @@ test_that("edge case: slab.structure[2] > max(x)", {
   expect_equivalent(a$value, 13.58427, tolerance=0.001)
 })
 
+test_that("edge case: slab.structure[1] > 0 (w/ custom slab function)", {
+  data(sp3, package = "aqp")
+  depths(sp3) <- id ~ top + bottom
+  
+  # custom 'slab' function, returning mean +/- 1SD
+  mean.and.sd <- function(values) {
+    m <- mean(values, na.rm = TRUE)
+    s <- sd(values, na.rm = TRUE)
+    upper <- m + s
+    lower <- m - s
+    res <- c(mean = m,
+             lower = lower,
+             upper = upper)
+    return(res)
+  }
+  
+  ## this time, compute the weighted mean of selected properties, by profile ID
+  a <- slab(sp3,
+            fm = id ~ L + A + B,
+            slab.structure = c(40, 60), 
+            slab.fun = mean.and.sd
+  )
+  
+  # convert long -> wide
+  res <- data.table::dcast(
+    data.table::as.data.table(a),
+    formula = id + top + bottom ~ variable,
+    value.var = 'mean'
+  )
+  
+  expect_equal(nrow(res), length(sp3))
+  expect_equal(ncol(res), 6L)
+})
 
 test_that("overlapping horizons", {
   data(sp4, package = 'aqp')


### PR DESCRIPTION
@dylanbeaudette found a couple issues with dontrun examples in `slab()` that I have made some preliminary corrections for.

Issue 1: related to the data type of an all NA column being logical rather than double -- corrected by using `as.numeric()` in `.slab.fun.numeric.HD()`

Issue 2: related to a case we didn't have tests for and apparently had not been checked/identified as a problem since the `slab()` rewrite 
 -  `.genSlabLabels2()` has been corrected to adjust for minimum slice depth within a slab. Previously was returning all NA labels in cases where `slab.structure[1] > 0`. Added a new test for this case. 

Also small correction to `slab()` example for recent update to `get.ml.hz()` in https://github.com/ncss-tech/aqp/commit/a8932cfed95caedc0f418c56a43e0747b4632fcc
