### PR TITLE
`flagOverlappingHz()` performance improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,6 @@ URL: https://github.com/ncss-tech/aqp, https://ncss-tech.github.io/AQP/
 BugReports: https://github.com/ncss-tech/aqp/issues
 Language: en-US
 Encoding: UTF-8
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/R/flagOverlappingHz.R
+++ b/R/flagOverlappingHz.R
@@ -34,27 +34,26 @@
 #' 
 flagOverlappingHz <- function(x) {
   h <- horizons(x)
+  idn <- idname(x)
   hzd <- horizonDepths(x)
   
-  # extract horizon depths
-  .tops <- h[[hzd[1]]]
-  .bottoms <- h[[hzd[2]]]
+  # extract horizon depths and profile ID
+  .id <- h[[idn]]
+  .fid <- as.numeric(factor(.id))
+  .tops <- paste0(.fid, ":", h[[hzd[1]]])
+  .bottoms <- paste0(.fid, ":", h[[hzd[2]]])
   
-  # recode missing depths so they will be recognized as runs with length >1
-  .topna <- is.na(.tops)
-  .botna <- is.na(.bottoms)
-  .tops[.topna] <- -9999
-  .botna[.botna] <- -9999
+  # missing depths are recoded so they will be recognized as runs with length >1
   
   .rt <- rle(.tops) 
   .rb <- rle(.bottoms)
-  
   .ot <- .rt$values[which(.rt$lengths > 1)]
   .ob <- .rb$values[which(.rb$lengths > 1)]
   
   # index affected horizons
   .m1 <- outer(.ot, .tops, '==') 
   .m2 <- outer(.ob, .bottoms, '==')
+  
   idx1 <- unlist(as.vector(apply(.m1, 1, which)))
   idx2 <- unlist(as.vector(apply(.m2, 1, which)))
   

--- a/R/flagOverlappingHz.R
+++ b/R/flagOverlappingHz.R
@@ -31,16 +31,12 @@
 flagOverlappingHz <- function(x) {
   
   # crude prototype, single profile at a time
-  .fo <- function(i) {
-    
-    # for R CMD check
-    .TOP <- NULL
-    .BOTTOM <- NULL
+  .fo <- function(i, hzd) {
     
     # tops / bottoms
     # NA not currently handled
-    .tops <- i[, , .TOP]
-    .bottoms <- i[, , .BOTTOM]
+    .tops <- i[[hzd[1]]]
+    .bottoms <- i[[hzd[2]]]
     
     # find perfect overlap
     .rt <- rle(.tops)
@@ -62,10 +58,9 @@ flagOverlappingHz <- function(x) {
     return(.res)
   }
   
-  # TODO: can probably be made faster
-  #  * only hz data required
-  #  * split (profile ID) / apply (.fo()) / combine via DT (returns vector)
-  res <- profileApply(x, .fo, simplify = TRUE)
-  return(res)
+  h <- data.table::data.table(horizons(x))
+  l <- list(h[[idname(x)]])
+  names(l) <- idname(x)
+  h[, .fo(.SD, horizonDepths(x)), by = l]$V1
 }
 

--- a/R/flagOverlappingHz.R
+++ b/R/flagOverlappingHz.R
@@ -5,9 +5,13 @@
 #'
 #' @return logical vector with length (and order) matching the horizons of `x` 
 #' 
-#' @author D.E. Beaudette
+#' @author D.E. Beaudette, A.G. Brown
 #' 
 #' @export
+#' @details
+#' Horizons with `NA` depths are are not flagged as overlapping. Find and remove or fix these with `checkHzDepthLogic(byhz=TRUE)` if needed.
+#' 
+#' @seealso [checkHzDepthLogic()] [fillHzGaps()]
 #'
 #' @examples
 #' 
@@ -32,29 +36,28 @@ flagOverlappingHz <- function(x) {
   h <- horizons(x)
   hzd <- horizonDepths(x)
   
-  # TODO: horizons with NA depths are not flagged as overlapping
-  # TODO: bottom depths are never used or compared
+  # NOTE: horizons with NA depths are not flagged as overlapping
+  #  - rle gives length 1 for each NA; could recode NA values before rle?
   
   .tops <- h[[hzd[1]]]
-  # .bottoms <- h[[hzd[2]]]
+  .bottoms <- h[[hzd[2]]]
+  .rt <- rle(.tops) 
+  .rb <- rle(.bottoms)
   
-  .rt <- rle(.tops) # NOTE: rle gives length 1 for each NA
-  # .rb <- rle(.bottoms)
-  
+  # TODO: need alternative to rle() lengths here
   .ot <- .rt$values[which(.rt$lengths > 1)]
-  # .ob <- .rb$values[which(.rt$lengths > 1)]
+  .ob <- .rb$values[which(.rb$lengths > 1)]
   
   # index affected horizons
-  # TODO: handle NA in logical comparisons
+  # TODO: handle NA in logical comparisons?
   .m1 <- outer(.ot, .tops, '==') 
-  # .m2 <- outer(.ob, .bottoms, '==') 
+  .m2 <- outer(.ob, .bottoms, '==')
   idx1 <- unlist(as.vector(apply(.m1, 1, which)))
-  # idx2 <- unlist(as.vector(apply(.m2, 1, which)))
+  idx2 <- unlist(as.vector(apply(.m2, 1, which)))
   
   # generate flag vector along sequence of horizons 
   .res <- rep(FALSE, times = length(.tops))
-  # .res[intersect(idx1, idx2)] <- TRUE
-  .res[idx1] <- TRUE
+  .res[intersect(idx1, idx2)] <- TRUE
   .res
 }
 

--- a/R/flagOverlappingHz.R
+++ b/R/flagOverlappingHz.R
@@ -29,38 +29,32 @@
 #' depth.axis = FALSE, cex.names = 0.85)
 #' 
 flagOverlappingHz <- function(x) {
+  h <- horizons(x)
+  hzd <- horizonDepths(x)
   
-  # crude prototype, single profile at a time
-  .fo <- function(i, hzd) {
-    
-    # tops / bottoms
-    # NA not currently handled
-    .tops <- i[[hzd[1]]]
-    .bottoms <- i[[hzd[2]]]
-    
-    # find perfect overlap
-    .rt <- rle(.tops)
-    .rb <- rle(.bottoms)
-    
-    # id affected horizons
-    .ot <- .rt$values[which(.rt$lengths > 1)]
-    .ob <- .rb$values[which(.rb$lengths > 1)]
-    
-    ## TODO: tests required
-    # index affected horizons
-    .m <- outer(.ot, .tops, '==')
-    idx <- unlist(as.vector(apply(.m, 1, which)))
-    
-    # generate flag vector along sequence of horizons 
-    .res <- rep(FALSE, times = length(.tops))
-    .res[idx] <- TRUE
-    
-    return(.res)
-  }
+  # TODO: horizons with NA depths are not flagged as overlapping
+  # TODO: bottom depths are never used or compared
   
-  h <- data.table::data.table(horizons(x))
-  l <- list(h[[idname(x)]])
-  names(l) <- idname(x)
-  h[, .fo(.SD, horizonDepths(x)), by = l]$V1
+  .tops <- h[[hzd[1]]]
+  # .bottoms <- h[[hzd[2]]]
+  
+  .rt <- rle(.tops) # NOTE: rle gives length 1 for each NA
+  # .rb <- rle(.bottoms)
+  
+  .ot <- .rt$values[which(.rt$lengths > 1)]
+  # .ob <- .rb$values[which(.rt$lengths > 1)]
+  
+  # index affected horizons
+  # TODO: handle NA in logical comparisons
+  .m1 <- outer(.ot, .tops, '==') 
+  # .m2 <- outer(.ob, .bottoms, '==') 
+  idx1 <- unlist(as.vector(apply(.m1, 1, which)))
+  # idx2 <- unlist(as.vector(apply(.m2, 1, which)))
+  
+  # generate flag vector along sequence of horizons 
+  .res <- rep(FALSE, times = length(.tops))
+  # .res[intersect(idx1, idx2)] <- TRUE
+  .res[idx1] <- TRUE
+  .res
 }
 

--- a/R/flagOverlappingHz.R
+++ b/R/flagOverlappingHz.R
@@ -9,7 +9,7 @@
 #' 
 #' @export
 #' @details
-#' Horizons with `NA` depths are are not flagged as overlapping. Find and remove or fix these with `checkHzDepthLogic(byhz=TRUE)` if needed.
+#' Horizons with `NA` depths can be flagged as overlapping. Consider finding these horizons with `checkHzDepthLogic(byhz=TRUE)` and removing or fixing them.
 #' 
 #' @seealso [checkHzDepthLogic()] [fillHzGaps()]
 #'
@@ -36,20 +36,23 @@ flagOverlappingHz <- function(x) {
   h <- horizons(x)
   hzd <- horizonDepths(x)
   
-  # NOTE: horizons with NA depths are not flagged as overlapping
-  #  - rle gives length 1 for each NA; could recode NA values before rle?
-  
+  # extract horizon depths
   .tops <- h[[hzd[1]]]
   .bottoms <- h[[hzd[2]]]
+  
+  # recode missing depths so they will be recognized as runs with length >1
+  .topna <- is.na(.tops)
+  .botna <- is.na(.bottoms)
+  .tops[.topna] <- -9999
+  .botna[.botna] <- -9999
+  
   .rt <- rle(.tops) 
   .rb <- rle(.bottoms)
   
-  # TODO: need alternative to rle() lengths here
   .ot <- .rt$values[which(.rt$lengths > 1)]
   .ob <- .rb$values[which(.rb$lengths > 1)]
   
   # index affected horizons
-  # TODO: handle NA in logical comparisons?
   .m1 <- outer(.ot, .tops, '==') 
   .m2 <- outer(.ob, .bottoms, '==')
   idx1 <- unlist(as.vector(apply(.m1, 1, which)))

--- a/man/flagOverlappingHz.Rd
+++ b/man/flagOverlappingHz.Rd
@@ -15,6 +15,9 @@ logical vector with length (and order) matching the horizons of \code{x}
 \description{
 Flag perfectly overlapping horizons within a SoilProfileCollection
 }
+\details{
+Horizons with \code{NA} depths can be flagged as overlapping. Consider finding these horizons with \code{checkHzDepthLogic(byhz=TRUE)} and removing or fixing them.
+}
 \examples{
 
 # two overlapping horizons
@@ -35,6 +38,9 @@ plotSPC(z, color = '.overlapFlag', hz.depths = TRUE,
 depth.axis = FALSE, cex.names = 0.85)
 
 }
+\seealso{
+\code{\link[=checkHzDepthLogic]{checkHzDepthLogic()}} \code{\link[=fillHzGaps]{fillHzGaps()}}
+}
 \author{
-D.E. Beaudette
+D.E. Beaudette, A.G. Brown
 }

--- a/tests/testthat/test-flagOverlappingHz.R
+++ b/tests/testthat/test-flagOverlappingHz.R
@@ -69,3 +69,47 @@ test_that("edge case", {
                  TRUE, TRUE, TRUE, 
                  FALSE, FALSE))
 })
+
+
+z3 <- data.frame(
+  id = 'SPC1',
+  top = c(0, 25, 25, 25, 50, 75, 100, 100),
+  bottom = c(25, 45, 50, 50, 75, 100, 125, 125)
+)
+
+z4 <- data.frame(
+  id = 'SPC2',
+  top = c(0, 25, 50, 75, 100),
+  bottom = c(25, 50, 75, 100, 125)
+)
+
+z5 <- rbind(z3, z4)
+depths(z5) <- id ~ top + bottom
+
+# test multiple profiles with some depths the same between both profiles
+# but only the first profile has overlap (1 imperfect, 2 perfect)
+test_that("multiple profiles, with and without overlap", {
+ .overlapFlag <- flagOverlappingHz(z5)
+ expect_false(any(.overlapFlag[9:13]))
+})
+
+z6 <- data.frame(
+  id = 'SPC1',
+  top = 0,
+  bottom = 100
+)
+
+z7 <- data.frame(
+  id = 'SPC2',
+  top = c(0, 0, 100),
+  bottom = c(100, 100, 200)
+)
+
+z8 <- rbind(z6, z7)
+depths(z8) <- id ~ top + bottom
+
+test_that("multiple profiles, edge case", {
+  # first single horizon profile matches depths that overlap in next profile
+  .overlapFlag <- flagOverlappingHz(z8)
+  expect_false(.overlapFlag[1])
+})

--- a/tests/testthat/test-flagOverlappingHz.R
+++ b/tests/testthat/test-flagOverlappingHz.R
@@ -10,7 +10,7 @@ z <- data.frame(
 depths(z) <- id ~ top + bottom
 
 # basic functionality
-test_that("flagOverlappingHz", {
+test_that("flagOverlappingHz: perfect overlap in 2 horizons", {
   
   .overlapFlag <- flagOverlappingHz(z)
   
@@ -26,6 +26,29 @@ test_that("flagOverlappingHz", {
   
 })
 
+z2 <- data.frame(
+  id = 'SPC',
+  top = c(0, 25, 25, 25, 50, 75, 100, 100),
+  bottom = c(25, 45, 50, 50, 75, 100, 125, 125)
+)
+
+depths(z2) <- id ~ top + bottom
+
+test_that("flagOverlappingHz: imperfect in 1 horizon, perfect in 2 horizons", {
+  
+  .overlapFlag <- flagOverlappingHz(z2)
+  
+  # logical vector
+  expect_true(length(.overlapFlag) == nrow(z2))
+  expect_true(inherits(.overlapFlag, 'logical'))
+  
+  # not overlapping horizons
+  expect_true(all(!.overlapFlag[c(1, 2, 5, 6)]))
+  
+  # overlapping horizons
+  expect_true(all(.overlapFlag[c(3, 4, 7, 8)]))
+  
+})
 
 # more complex edge case
 x <- data.frame(peiid = c("1373969", "1373969", "1373969", "1373969", 


### PR DESCRIPTION
`flagOverlappingHz()` is called by `fillHzGaps()` which is used by several higher level functions including:
- `dice()` / `slab()` 
- `profileInformationIndex()`
- `spc2mpspline()`

The current implementation of `flagOverlappingHz()` on master branch is slow, based on iteration over single profile SPCs, and complex operations on each element... it is the major bottleneck in `fillHzGaps()`.

This PR improves processing time by approximately 4 orders of magnitude with a 10,000 profile SoilProfileCollection. It also allows for flagging overlap in horizons that have missing depths (a TODO item), improves tests, and ensures that _imperfectly_ overlapping horizons are not flagged.

```r
library(aqp)
#> This is aqp 2.0.3

x <- data.table::rbindlist(lapply(1:10000, random_profile, SPC = FALSE))
depths(x) <- id ~ top + bottom

# flag overlap in 10k random profiles (that have no overlap)
system.time(flagOverlappingHz(x))

## BEFORE
#>   user  system elapsed 
#> 98.309   0.483  98.877 

## AFTER
#>  user  system elapsed 
#> 0.002   0.006   0.013 
```