### PR TITLE
Remove `"original.order"` from SPC metadata

### DIFF
--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -200,15 +200,8 @@ setClass(
       aqp_hzdesgn = "",
       aqp_hztexcl = "",
       depth_units = 'cm',
-      stringsAsFactors = FALSE,
-
-      # calculate data order (original)
-      original.order = order(as.character(horizons[[idcol]]),
-                             horizons[[depthcols[1]]])
+      stringsAsFactors = FALSE
     )
-
-    # the target order to check/maintain is the default for a new SPC
-    # metadata$target.order <- metadata$original.order
 
     # add any custom metadata
     metadata <- c(metadata,

--- a/R/SoilProfileCollection-integrity.R
+++ b/R/SoilProfileCollection-integrity.R
@@ -94,10 +94,7 @@ setMethod('reorderHorizons',
             
             h <- object@horizons
             
-            if (is.null(target.order))
-              target.order <- metadata(object)$original.order
-              if (is.null(target.order))
-                target.order <- 1:nrow(h)
+            stopifnot(!is.null(target.order))
             
             current.order <- match(target.order,
                                    order(as.character(h[[idname(object)]]),

--- a/R/SoilProfileCollection-metadata.R
+++ b/R/SoilProfileCollection-metadata.R
@@ -73,7 +73,9 @@
   customattr <- customattr[!names(customattr) %in% names(attributes(SoilProfileCollection()))]
   attributes(dest)[names(customattr)] <- attributes(src)[names(customattr)]
   
+  # original.order metadata no longer created, not transferred
   cols <- names(m)[names(m) != "original.order"]
+  
   metadata(dest)[cols] <- m[cols]
   dest
 }

--- a/tests/testthat/test-SPC-objects.R
+++ b/tests/testthat/test-SPC-objects.R
@@ -611,15 +611,15 @@ test_that("basic integrity checks", {
   expect_true(spc_in_sync(spc[0,])$valid)
 
   # reordering the horizons with reorderHorizons resolves integrity issues
-  expect_true(spc_in_sync(reorderHorizons(spc))$valid)
+  expect_true(spc_in_sync(reorderHorizons(spc, seq(nrow(spc))))$valid)
 
-  # default reordering uses metadata$original.order, here we override and reverse it
-  expect_false(spc_in_sync(reorderHorizons(spc, rev(spc@metadata$original.order)))$valid)
+  # override and reverse it
+  expect_false(spc_in_sync(reorderHorizons(spc, rev(seq(nrow(spc)))))$valid)
 
   # removing the metadata works because target order matches sequential order
   #  this cannot be guaranteed to be the case in general but is a reasonable default
   spc@metadata$target.order <- NULL
-  expect_true(spc_in_sync(reorderHorizons(spc))$valid)
+  expect_true(spc_in_sync(reorderHorizons(spc, seq(nrow(spc))))$valid)
 
   # reordering horizons with any order works, even if invalid
   spc <- reorderHorizons(spc, target.order = c(20:40,1:19))


### PR DESCRIPTION
This was only used for `reorderHorizons()` default functionality. It is rare that this function is used, nor that we don't know the desired target order. `reorderHorizons()` now requires `target.order` be specified 

Metadata with a numeric vector of the order of input data was set for every SPC (which could be a bit costly in terms of time/memory for large SPCs) but only was used for `reorderHorizons()` which is rarely needed or used.

This metadata entry, and the formerly present `target.order` metadata, were held over from my ideas on how to implement alternate profile sorting methods (i.e. not dependent on alpha sorting of profile ID + top depth). We decided to not change the historic sorting behavior.

I think that the better way to implement numeric/alternate profile sorting in the SPC--if we ever want to--would be to have some sort of an internal numeric profile ID assigned at object creation (i.e. `as.integer(factor(horizons(x)[[idname(x)]]))`) rather than relying on profile ID (character) sorting. 