### PR TITLE
`generalize.hz(hzdepm = ...)`: more robust sorting in presence of missing depths

### DIFF
--- a/man/generalize.hz.Rd
+++ b/man/generalize.hz.Rd
@@ -14,6 +14,7 @@ generalize.hz(
   non.matching.code = "not-used",
   hzdepm = NULL,
   ordered = !missing(hzdepm),
+  na.rm = TRUE,
   ...
 )
 
@@ -49,14 +50,16 @@ generalize.hz(
 
 \item{hzdepm}{numeric vector of horizon mid-points; \code{NA} values in \code{hzdepm} will result in \code{non.matching.code} (or \code{NA} if not defined) in result}
 
-\item{ordered}{logical, \code{TRUE} when \code{hzdepm} argument is specified}
+\item{ordered}{logical, default \code{TRUE} when \code{hzdepm} argument is specified}
+
+\item{na.rm}{logical, default \code{TRUE} will ignore missing depths in calculating sort order when \code{hzdepm} is specified and \code{ordered=TRUE}}
 
 \item{...}{additional arguments passed to \code{grep()} such as \code{perl = TRUE} for advanced REGEX}
 
 \item{ghl}{Generalized Horizon Designation column name (to be created/updated when \code{x} is a \code{SoilProfileCollection})}
 }
 \value{
-factor (possibly an ordered factor) of the same length as \code{x} (if character) or as number of horizons in \code{x} (if \code{SoilProfileCollection})
+factor (an ordered factor when \code{ordered=TRUE}) of the same length as \code{x} (if character) or as number of horizons in \code{x} (if \code{SoilProfileCollection})
 }
 \description{
 Generalize a vector of horizon names, based on new classes, and REGEX


### PR DESCRIPTION
This PR addresses behavior of `generalize.hz()` when `hzdepm` contains `NA`. It adds `na.rm` argument for finer-tuned handling of missing depths. This argument affects both the handling of `NA` values by `median()` and the `sort()` behavior for a cases where median is `NA`

``` r
library(aqp)
#> This is aqp 2.1.0
data(sp4)
depths(sp4) <- id ~ top + bottom
hzdesgnname(sp4) <- "name"

sp4_1 <- generalizeHz(sp4, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean))
generalize.hz(sp4$name, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean))
#>  [1] A  Bt Bt Bt A  Bt A  Bt Bt A  Bt Bt Bt A  Bt Bt A  Bt A  Bt A  Bt A  A  A 
#> [26] Bt Bt A  Bt Bt
#> Levels: A < Bt < not-used
table(sp4_1$genhz)
#> 
#>        A       Bt not-used 
#>       12       18        0
plot(sp4_1, color = "genhz")
```

![](https://i.imgur.com/qBZH51d.png)<!-- -->

``` r

# replace several top depths
sp4$top[4:5] <- NA

sp4_2 <- generalizeHz(sp4, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean))
generalize.hz(sp4$name, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean))
#>  [1] not-used not-used not-used not-used not-used not-used not-used not-used
#>  [9] not-used not-used not-used not-used not-used not-used not-used not-used
#> [17] not-used not-used not-used not-used not-used not-used not-used not-used
#> [25] not-used not-used not-used not-used not-used not-used
#> Levels: not-used
table(sp4_2$genhz)
#> 
#> not-used 
#>       30
plot(sp4_2, color = "genhz")
```

![](https://i.imgur.com/QbkcQu9.png)<!-- -->

Only two `genhz` labels should be `"not-used"` because only two horizons are missing midpoints. The documentation says: 
 > "NA values in `hzdepm` will result in `non.matching.code` (or `NA` if not defined) in result"
 
With this PR I now get:

``` r
library(aqp)
#> This is aqp 2.1.0
data(sp4)
depths(sp4) <- id ~ top + bottom
hzdesgnname(sp4) <- "name"
```

``` r

# replace several top depths
sp4$top[4:5] <- NA

sp4_2 <- generalizeHz(sp4, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean))
generalize.hz(sp4$name, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean))
#>  [1] A        Bt       Bt       not-used not-used Bt       A        Bt      
#>  [9] Bt       A        Bt       Bt       Bt       A        Bt       Bt      
#> [17] A        Bt       A        Bt       A        Bt       A        A       
#> [25] A        Bt       Bt       A        Bt       Bt      
#> Levels: A < Bt < not-used
table(sp4_2$genhz)
#> 
#>        A       Bt not-used 
#>       11       17        2
plot(sp4_2, color = "genhz")
```

![](https://i.imgur.com/Qbh2TmM.png)<!-- -->

`na.rm=TRUE` is the same logic used in the `guessGenHzLevels()` routine, so is proposed to be default used in `generalize.hz()`

The original behavior can now be obtained with `na.rm=FALSE`:

``` r
sp4_3 <- generalizeHz(sp4, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean), na.rm = FALSE)
generalize.hz(sp4$name, c("A", "Bt"), c("A", "Bt"), hzdepm = apply(depths(sp4)[2:3], 1, mean), na.rm = FALSE)
#>  [1] not-used not-used not-used not-used not-used not-used not-used not-used
#>  [9] not-used not-used not-used not-used not-used not-used not-used not-used
#> [17] not-used not-used not-used not-used not-used not-used not-used not-used
#> [25] not-used not-used not-used not-used not-used not-used
#> Levels: not-used
table(sp4_3$genhz)
#> 
#> not-used 
#>       30
```



