### PR TITLE
feat: register .DollarNames for SoilProfileCollection objects

### DIFF
--- a/R/Class-SoilProfileCollection.R
+++ b/R/Class-SoilProfileCollection.R
@@ -1237,3 +1237,7 @@ setReplaceMethod("depth_units", signature(object = "SoilProfileCollection"),
                    return(object)
                  }
 )
+
+registerS3method(".DollarNames", "SoilProfileCollection", function(x, pattern) {
+  names(x)
+})


### PR DESCRIPTION
Fixes broken tab autocomplete with `$`  for SPC site and horizons column names in RStudio and other IDEs. 
 
It used to be sufficient to just have `names()` defined for SPC, but that does not work any more, and this has been driving me nuts.