### PR TITLE
fix: placeholder data.frame objects for "dropped" profiles

### DIFF
--- a/R/SoilProfileCollection-setters.R
+++ b/R/SoilProfileCollection-setters.R
@@ -128,13 +128,13 @@ setReplaceMethod("depths", "data.frame",
   # add other columns
   if (ncol(hz) > 0) {
     hz$.dummyVar <- ""[nrow(hz)]
-    nuhz <- cbind(nuhz, hz[0, !colnames(hz) %in% colnames(nuhz), drop = FALSE][iid,])
+    nuhz <- cbind(nuhz, .create_placeholder_df(hz[, !colnames(hz) %in% colnames(nuhz), drop = FALSE], length(iid)))
     nuhz$.dummyVar <- NULL
   }
   
   if (ncol(st) > 0) {
     st$.dummyVar <- ""[nrow(st)]
-    nust <- cbind(nust, st[0, !colnames(st) %in% colnames(nust), drop = FALSE][iid,])
+    nust <- cbind(nust, .create_placeholder_df(st[, !colnames(st) %in% colnames(nust), drop = FALSE], length(iid)))
     nust$.dummyVar <- NULL
   }
     


### PR DESCRIPTION
Will close #347. Adds new internal function `.create_placeholder_df()` which is now used internally in `.insert_dropped_horizons()` and `.prototypeSPC()` instead of `data.frame(...)[0, ][some_index, ]` which does not work with some vctrs classes.

Slightly better reprex than #347 with adjusted upper boundary of trunc depth so at least some profiles have horizons in the result:

``` r
library(aqp)
#> This is aqp 2.3.1
library(blob)

data(sp4)

depths(sp4) <- id ~ top + bottom
sp4$ShapeHorizon <- new_blob(as.list(as.raw(seq_len(nrow(sp4)))))
sp4$ShapeSite <- new_blob(as.list(as.raw(seq_len(length(sp4)))))

res <- trunc(sp4, 25, 100, drop = FALSE)

res$ShapeHorizon
#> <blob[12]>
#>  [1] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B]
#>  [8] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B]
res$ShapeSite
#> <blob[10]>
#>  [1] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B] blob[1 B]
#>  [8] blob[1 B] blob[1 B] blob[1 B]

# values are preserved (except for inserted dropped values which go to 00 [equivalent to NA])
unclass(res$ShapeHorizon)
#> [[1]]
#> [1] 03
#> 
#> [[2]]
#> [1] 04
#> 
#> [[3]]
#> [1] 06
#> 
#> [[4]]
#> [1] 09
#> 
#> [[5]]
#> [1] 0c
#> 
#> [[6]]
#> [1] 0d
#> 
#> [[7]]
#> [1] 10
#> 
#> [[8]]
#> [1] 00
#> 
#> [[9]]
#> [1] 00
#> 
#> [[10]]
#> [1] 16
#> 
#> [[11]]
#> [1] 1b
#> 
#> [[12]]
#> [1] 00
#> 
#> attr(,"ptype")
#> raw(0)

plot(res)
```

![](https://i.imgur.com/Z2FUAzB.png)<!-- -->
